### PR TITLE
feat(director): 3D 导演台节点

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
     "type": "module",
     "scripts": {
         "postinstall": "node scripts/setup-hooks.js",
-        "dev": "vite",
+        "dev": "node scripts/dev-with-director.mjs",
+        "dev:web-only": "vite",
+        "director": "node scripts/ensure-director-desk.mjs",
         "lint": "eslint .",
         "typecheck": "tsc -b",
         "test:typecheck": "tsc -p tsconfig.test.json --noEmit",
@@ -15,7 +17,8 @@
         "ci": "npm run check && npm run build",
         "build": "tsc -b && vite build",
         "preview": "vite preview",
-        "tauri": "tauri",
+        "tauri": "node scripts/tauri-with-director.mjs",
+        "tauri:raw": "tauri",
         "sync-version": "node scripts/sync-version.js"
     },
     "dependencies": {

--- a/scripts/dev-with-director.mjs
+++ b/scripts/dev-with-director.mjs
@@ -1,0 +1,43 @@
+/**
+ * npm run dev 包装：先拉起 3D 导演台，再启动 Vite 前端
+ */
+import { spawn } from 'node:child_process';
+import { ensureDirectorDeskRunning, stopDirectorDeskIfStartedByUs } from './ensure-director-desk.mjs';
+
+async function main() {
+  try {
+    await ensureDirectorDeskRunning();
+  } catch (err) {
+    console.warn('[director-desk] 自动启动失败，继续打开前端:', err?.message || err);
+  }
+
+  const child = spawn('vite', process.argv.slice(2), {
+    stdio: 'inherit',
+    shell: true,
+    env: process.env,
+  });
+
+  const forward = (signal) => {
+    try {
+      child.kill(signal);
+    } catch {
+      /* ignore */
+    }
+  };
+  process.on('SIGINT', () => forward('SIGINT'));
+  process.on('SIGTERM', () => forward('SIGTERM'));
+
+  child.on('exit', (code, signal) => {
+    stopDirectorDeskIfStartedByUs();
+    if (signal) {
+      process.kill(process.pid, signal);
+      return;
+    }
+    process.exit(code ?? 0);
+  });
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/ensure-director-desk.mjs
+++ b/scripts/ensure-director-desk.mjs
@@ -1,0 +1,175 @@
+/**
+ * 确保本地 3D 导演台（xiaozangao/3d-director-desk）在 5173 运行。
+ * 单独运行: node scripts/ensure-director-desk.mjs
+ * 也可: npm run director
+ */
+import { spawn } from 'node:child_process';
+import { existsSync, mkdirSync, writeFileSync, readFileSync, unlinkSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+export const DIRECTOR_ORIGIN = process.env.DIRECTOR_DESK_ORIGIN || 'http://127.0.0.1:5173';
+export const DIRECTOR_DIR =
+  process.env.DIRECTOR_DESK_DIR || resolve(homedir(), 'Projects', '3d-director-desk');
+
+const PID_FILE = join(homedir(), '.cache', 'ai-canvas-director-desk.pid');
+
+async function isDirectorUp(origin = DIRECTOR_ORIGIN, timeoutMs = 1200) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(origin, { signal: controller.signal });
+    return res.ok || res.status === 200 || res.status === 304;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function savePid(pid) {
+  try {
+    mkdirSync(join(homedir(), '.cache'), { recursive: true });
+    writeFileSync(PID_FILE, String(pid), 'utf8');
+  } catch {
+    /* ignore */
+  }
+}
+
+function readSavedPid() {
+  try {
+    const pid = Number(readFileSync(PID_FILE, 'utf8').trim());
+    return Number.isFinite(pid) ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+function isProcessAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * @returns {Promise<{ started: boolean, origin: string }>}
+ */
+export async function ensureDirectorDeskRunning() {
+  if (await isDirectorUp()) {
+    console.log(`[director-desk] 已在运行: ${DIRECTOR_ORIGIN}`);
+    return { started: false, origin: DIRECTOR_ORIGIN };
+  }
+
+  if (!existsSync(DIRECTOR_DIR)) {
+    console.warn(
+      `[director-desk] 未找到目录: ${DIRECTOR_DIR}\n` +
+        `  请先: git clone https://github.com/xiaozangao/3d-director-desk.git "${DIRECTOR_DIR}"\n` +
+        `  或设置环境变量 DIRECTOR_DESK_DIR`,
+    );
+    return { started: false, origin: DIRECTOR_ORIGIN };
+  }
+
+  if (!existsSync(join(DIRECTOR_DIR, 'node_modules'))) {
+    console.log('[director-desk] 首次安装依赖…');
+    await new Promise((resolvePromise, reject) => {
+      const install = spawn('npm', ['install'], {
+        cwd: DIRECTOR_DIR,
+        stdio: 'inherit',
+        shell: true,
+        env: process.env,
+      });
+      install.on('exit', (code) =>
+        code === 0 ? resolvePromise() : reject(new Error(`npm install 失败: ${code}`)),
+      );
+    });
+  }
+
+  console.log(`[director-desk] 启动中 → ${DIRECTOR_ORIGIN}`);
+  console.log(`[director-desk] 目录: ${DIRECTOR_DIR}`);
+
+  const child = spawn(
+    'npm',
+    ['run', 'dev', '--', '--host', '127.0.0.1', '--port', '5173'],
+    {
+      cwd: DIRECTOR_DIR,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      shell: true,
+      env: process.env,
+      detached: true,
+    },
+  );
+
+  child.unref();
+  if (child.pid) savePid(child.pid);
+
+  child.stdout?.on('data', (buf) => {
+    const text = buf.toString();
+    if (/Local:|ready in|error/i.test(text)) {
+      process.stdout.write(`[director-desk] ${text}`);
+    }
+  });
+  child.stderr?.on('data', (buf) => {
+    const text = buf.toString();
+    if (/error|ERR|EADDRINUSE/i.test(text)) {
+      process.stderr.write(`[director-desk] ${text}`);
+    }
+  });
+
+  for (let i = 0; i < 40; i++) {
+    await sleep(500);
+    if (await isDirectorUp()) {
+      console.log(`[director-desk] 就绪: ${DIRECTOR_ORIGIN}`);
+      return { started: true, origin: DIRECTOR_ORIGIN };
+    }
+  }
+
+  console.warn(
+    `[director-desk] 启动超时，画布仍会继续打开；请检查 ${DIRECTOR_ORIGIN}\n` +
+      `  或手动: npm run director`,
+  );
+  return { started: true, origin: DIRECTOR_ORIGIN };
+}
+
+export function stopDirectorDeskIfStartedByUs() {
+  if (process.env.DIRECTOR_DESK_KILL_ON_EXIT !== '1') return;
+  const pid = readSavedPid();
+  if (!pid || !isProcessAlive(pid)) {
+    try {
+      unlinkSync(PID_FILE);
+    } catch {
+      /* ignore */
+    }
+    return;
+  }
+  try {
+    process.kill(-pid, 'SIGTERM');
+  } catch {
+    try {
+      process.kill(pid, 'SIGTERM');
+    } catch {
+      /* ignore */
+    }
+  }
+  try {
+    unlinkSync(PID_FILE);
+  } catch {
+    /* ignore */
+  }
+}
+
+const thisFile = fileURLToPath(import.meta.url);
+const invoked = process.argv[1] && resolve(process.argv[1]) === thisFile;
+
+if (invoked) {
+  ensureDirectorDeskRunning()
+    .then(() => process.exit(0))
+    .catch((err) => {
+      console.error(err);
+      process.exit(1);
+    });
+}

--- a/scripts/start-director-desk.sh
+++ b/scripts/start-director-desk.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# 单独启动 3D 导演台（一般不必手动跑：npm run tauri dev 会自动拉起）
+set -euo pipefail
+cd "$(dirname "$0")/.."
+exec node scripts/ensure-director-desk.mjs

--- a/scripts/tauri-with-director.mjs
+++ b/scripts/tauri-with-director.mjs
@@ -1,0 +1,51 @@
+/**
+ * npm run tauri 的包装：
+ * - `npm run tauri dev` 会先自动拉起 3D 导演台，再启动无限画布
+ * - `npm run tauri build` 等其它子命令不启动导演台
+ */
+import { spawn } from 'node:child_process';
+import { ensureDirectorDeskRunning, stopDirectorDeskIfStartedByUs } from './ensure-director-desk.mjs';
+
+const args = process.argv.slice(2);
+const isDev = args[0] === 'dev';
+
+async function main() {
+  if (isDev) {
+    try {
+      await ensureDirectorDeskRunning();
+    } catch (err) {
+      console.warn('[director-desk] 自动启动失败，继续打开画布:', err?.message || err);
+    }
+  }
+
+  const child = spawn('tauri', args, {
+    stdio: 'inherit',
+    shell: true,
+    env: process.env,
+  });
+
+  const forward = (signal) => {
+    try {
+      child.kill(signal);
+    } catch {
+      /* ignore */
+    }
+  };
+
+  process.on('SIGINT', () => forward('SIGINT'));
+  process.on('SIGTERM', () => forward('SIGTERM'));
+
+  child.on('exit', (code, signal) => {
+    stopDirectorDeskIfStartedByUs();
+    if (signal) {
+      process.kill(process.pid, signal);
+      return;
+    }
+    process.exit(code ?? 0);
+  });
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -57,6 +57,12 @@ function PanoramaNode(props: { id: string; data: BaseNodeData; selected?: boolea
   return <Suspense fallback={null}><PanoramaNodeLazy {...props} /></Suspense>;
 }
 
+// 懒加载：3D 导演台节点以 iframe 嵌入本地导演台
+const DirectorDeskNodeLazy = lazy(() => import('./nodes/DirectorDeskNode'));
+function DirectorDeskNode(props: { id: string; data: BaseNodeData; selected?: boolean }) {
+  return <Suspense fallback={null}><DirectorDeskNodeLazy {...props} /></Suspense>;
+}
+
 // ── Node types mapping ──
 const nodeTypes: NodeTypes = {
   'ai-text': TextNode,
@@ -67,6 +73,7 @@ const nodeTypes: NodeTypes = {
   'ai-panorama': PanoramaNode,
   'ai-markdown': MarkdownNode,
   'ai-storyboard': StoryboardNode,
+  'ai-director': DirectorDeskNode,
   group: GroupNode,
 };
 
@@ -128,6 +135,7 @@ const minimapNodeColor = (node: RFNode) => {
     case 'ai-animation': return 'color-mix(in srgb, var(--brand) 50%, transparent)';
     case 'ai-panorama': return 'color-mix(in srgb, var(--node-panorama) 50%, transparent)';
     case 'ai-markdown': return 'color-mix(in srgb, var(--node-markdown-light) 50%, transparent)';
+    case 'ai-director': return 'color-mix(in srgb, #a78bfa 50%, transparent)';
     case 'group': return '#4b556380';
     default: return '#6b728080';
   }

--- a/src/components/NodeMenu.tsx
+++ b/src/components/NodeMenu.tsx
@@ -47,10 +47,16 @@ const menuItems: { type: NodeType; label: string; icon: JSX.Element; badge?: str
     icon: <Icon icon={NODE_TYPE_CONFIG['ai-animation'].icon} width="18" height="18" />,
     badge: 'Sprite',
   },
+  {
+    type: 'ai-director',
+    label: '3D导演台',
+    icon: <Icon icon={NODE_TYPE_CONFIG['ai-director'].icon} width="18" height="18" />,
+    badge: '3D',
+  },
 ];
 
 const NODE_MENU_W = 240;
-const NODE_MENU_H = 338; // 5 items + header + footer
+const NODE_MENU_H = 390; // items + header + footer
 
 export default function NodeMenu() {
   const { nodeMenuVisible, nodeMenuPosition, hideNodeMenu, addNode, currentProjectId, showToast } = useAppStore(
@@ -80,6 +86,7 @@ export default function NodeMenu() {
   const handleAddNode = (type: NodeType) => {
     const isImage = type === 'ai-image';
     const isAnimation = type === 'ai-animation';
+    const isDirector = type === 'ai-director';
     const pos = getCanvasPointerPosition();
     const newNode: Record<string, unknown> = {
       id: `node-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
@@ -90,8 +97,8 @@ export default function NodeMenu() {
         type,
         prompt: '',
         status: 'idle' as const,
-        nodeWidth: isAnimation ? 320 : 280,
-        nodeHeight: isImage ? 158 : isAnimation ? 358 : 160,
+        nodeWidth: isAnimation || isDirector ? 320 : 280,
+        nodeHeight: isDirector ? 240 : isImage ? 158 : isAnimation ? 358 : 160,
         ...(isImage ? { aspectRatio: '16:9', imageSize: '2K' } : {}),
         ...(isAnimation ? {
           prompt: '2D俯视角游戏角色，保持角色造型、朝向、比例和光照一致',
@@ -100,6 +107,11 @@ export default function NodeMenu() {
           animationPreviewMode: 'playing',
           aspectRatio: '1:1',
           imageSize: '2K',
+        } : {}),
+        ...(isDirector ? {
+          role: 'source',
+          directorStatus: 'idle',
+          directorCaptureUrls: [],
         } : {}),
       },
     };

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -25,7 +25,7 @@ import ProjectLibraryModal from './ProjectLibraryModal';
    Node picker menu items
    ============================================ */
 const generationItems: {
-  type: NodeType | '3d-director';
+  type: NodeType;
   label: string;
   sub: string;
   icon: JSX.Element;
@@ -65,6 +65,12 @@ const generationItems: {
     label: '生成动画',
     sub: '2D 角色逐帧动画',
     icon: <Icon icon={NODE_TYPE_CONFIG['ai-animation'].icon} width="18" height="18" />,
+  },
+  {
+    type: 'ai-director',
+    label: '3D 导演台',
+    sub: '运镜预演 · 截图供生视频',
+    icon: <Icon icon={NODE_TYPE_CONFIG['ai-director'].icon} width="18" height="18" />,
   },
 ];
 
@@ -468,13 +474,14 @@ function NodePicker({
     const isImage = type === 'ai-image';
     const isPanorama = type === 'ai-panorama';
     const isAnimation = type === 'ai-animation';
+    const isDirector = type === 'ai-director';
     const nodeData: Record<string, unknown> = {
       label: NODE_TYPE_CONFIG[type]?.label || generationItems.find((m) => m.type === type)?.label || '节点',
       type,
       prompt: '',
       status: 'idle' as const,
-      nodeWidth: isAnimation ? 320 : isPanorama ? 300 : 280,
-      nodeHeight: isImage ? 158 : isAnimation ? 358 : isPanorama ? 200 : 160,
+      nodeWidth: isAnimation || isDirector ? 320 : isPanorama ? 300 : 280,
+      nodeHeight: isDirector ? 240 : isImage ? 158 : isAnimation ? 358 : isPanorama ? 200 : 160,
     };
     if (isImage) {
       nodeData.aspectRatio = '16:9';
@@ -490,6 +497,11 @@ function NodePicker({
       nodeData.animationPreviewMode = 'playing';
       nodeData.aspectRatio = '1:1';
       nodeData.imageSize = '2K';
+    }
+    if (isDirector) {
+      nodeData.role = 'source';
+      nodeData.directorStatus = 'idle';
+      nodeData.directorCaptureUrls = [];
     }
     // Auto-fill default model from localStorage preference
     // 全景图节点回退到生图节点偏好
@@ -599,8 +611,7 @@ function NodePicker({
           scale={1.02}
           className="menu-row has-desc"
           onClick={() => {
-            if (type === '3d-director') return; // placeholder
-            handleAddNode(type as NodeType);
+            handleAddNode(type);
           }}
         >
           <div className="menu-ico">{icon}</div>

--- a/src/components/nodes/DirectorDeskNode.tsx
+++ b/src/components/nodes/DirectorDeskNode.tsx
@@ -1,0 +1,388 @@
+/**
+ * DirectorDeskNode — 3D 导演台节点
+ * 嵌入 xiaozangao/3d-director-desk（iframe），截图/导出回写本节点，可连线到生视频节点。
+ */
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Handle, Position } from '@xyflow/react';
+import { Icon } from '@iconify/react';
+import type { BaseNodeData } from '../../types';
+import NodeLabel from './shared/NodeLabel';
+import NodeError from './shared/NodeError';
+import GooeyBtn from './shared/GooeyBtn';
+import ResizeHandle from './shared/ResizeHandle';
+import FullscreenOverlay from '../shared/FullscreenOverlay';
+import { useNodeRename } from './shared/useNodeRename';
+import { useAppStore } from '../../store/useAppStore';
+import { saveDataUrlToProjectData, buildNodeFileName } from '../../services/fileService';
+import {
+  buildDirectorDeskIframeSrc,
+  collectDirectorImageUrls,
+  getDirectorDeskOrigin,
+  isDirectorDeskMessage,
+  postDirectorSession,
+  requestDirectorAction,
+  type DirectorCaptureItem,
+} from '../../services/directorDeskService';
+
+const DEFAULT_W = 320;
+const DEFAULT_H = 240;
+
+function DirectorDeskNode({
+  id,
+  data,
+  selected,
+}: {
+  id: string;
+  data: BaseNodeData;
+  selected?: boolean;
+}) {
+  const updateNodeData = useAppStore((s) => s.updateNodeData);
+  const updateNodeDataTransient = useAppStore((s) => s.updateNodeDataTransient);
+  const commitToHistory = useAppStore((s) => s.commitToHistory);
+  const currentProjectId = useAppStore((s) => s.currentProjectId);
+  const showToast = useAppStore((s) => s.showToast);
+  const theme = useAppStore((s) => s.config.theme);
+  const { displayLabel, handleRename } = useNodeRename(id, data, '3D 导演台');
+
+  const [open, setOpen] = useState(false);
+  const [ready, setReady] = useState(false);
+  const [busy, setBusy] = useState<string | null>(null);
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+
+  const instanceId = useMemo(
+    () => (typeof data.directorInstanceId === 'string' && data.directorInstanceId) || id,
+    [data.directorInstanceId, id],
+  );
+
+  const captureUrls = useMemo(
+    () => collectDirectorImageUrls(data),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [data.imageUrl, data.directorCaptureUrls],
+  );
+
+  const width = (data.nodeWidth as number) || DEFAULT_W;
+  const height = (data.nodeHeight as number) || DEFAULT_H;
+  const deskTheme: 'dark' | 'light' = theme === 'light' ? 'light' : 'dark';
+  const iframeSrc = buildDirectorDeskIframeSrc(instanceId, deskTheme);
+
+  useEffect(() => {
+    if (data.directorInstanceId === instanceId) return;
+    updateNodeDataTransient(id, { directorInstanceId: instanceId });
+  }, [data.directorInstanceId, id, instanceId, updateNodeDataTransient]);
+
+  const handleResize = useCallback(
+    (w: number, h: number) => {
+      updateNodeDataTransient(id, { nodeWidth: w, nodeHeight: h });
+    },
+    [id, updateNodeDataTransient],
+  );
+
+  const persistCaptures = useCallback(
+    async (captures: DirectorCaptureItem[]) => {
+      if (!captures.length) return;
+      const projectId = currentProjectId;
+      const nextUrls: string[] = Array.isArray(data.directorCaptureUrls)
+        ? [...(data.directorCaptureUrls as string[])]
+        : [];
+      const nextPaths: string[] = Array.isArray(data.directorCaptureFilePaths)
+        ? [...(data.directorCaptureFilePaths as string[])]
+        : [];
+
+      let added = 0;
+      for (const capture of captures) {
+        const dataUrl = capture.dataUrl?.trim();
+        if (!dataUrl?.startsWith('data:image/')) continue;
+
+        let imageUrl = dataUrl;
+        let filePath: string | undefined;
+        if (projectId) {
+          try {
+            const fileName = buildNodeFileName((data.label as string) || '导演台', 'png', 'director');
+            const saved = await saveDataUrlToProjectData(dataUrl, projectId, fileName);
+            if (saved?.assetUrl) imageUrl = saved.assetUrl;
+            if (saved?.filePath) filePath = saved.filePath;
+          } catch (err) {
+            console.warn('[DirectorDeskNode] 截图落盘失败，使用 data URL', err);
+          }
+        }
+
+        nextUrls.push(imageUrl);
+        if (filePath) nextPaths.push(filePath);
+        added += 1;
+      }
+
+      if (added === 0) {
+        showToast('未收到有效截图', 'error');
+        return;
+      }
+
+      const latest = nextUrls[nextUrls.length - 1];
+      const latestPath = nextPaths[nextPaths.length - 1];
+      updateNodeData(id, {
+        directorCaptureUrls: nextUrls.slice(-12),
+        directorCaptureFilePaths: nextPaths.slice(-12),
+        imageUrl: latest,
+        filePath: latestPath,
+        thumbnailUrl: latest,
+        status: 'success',
+        error: undefined,
+        directorStatus: 'ready',
+      });
+      showToast(`已同步 ${added} 张导演台截图到节点`);
+    },
+    [currentProjectId, data.directorCaptureFilePaths, data.directorCaptureUrls, data.label, id, showToast, updateNodeData],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+
+    function onMessage(event: MessageEvent) {
+      if (!isDirectorDeskMessage(event)) return;
+      const type = event.data?.type as string | undefined;
+      if (!type) return;
+
+      if (type === 'storyai:director-desk-ready') {
+        setReady(true);
+        const win = iframeRef.current?.contentWindow;
+        if (win) {
+          postDirectorSession(win, { instanceId, theme: deskTheme });
+        }
+        updateNodeDataTransient(id, { directorStatus: 'ready' });
+        return;
+      }
+
+      if (type === 'storyai:director-desk-close') {
+        setOpen(false);
+        return;
+      }
+
+      if (type === 'storyai:director-desk-captures-sent') {
+        const captures = (event.data?.payload?.captures ?? []) as DirectorCaptureItem[];
+        void persistCaptures(
+          captures
+            .map((c) => ({
+              dataUrl: String(c?.dataUrl || ''),
+              fileName: String(c?.fileName || 'director-capture.png'),
+            }))
+            .filter((c) => c.dataUrl.startsWith('data:image/')),
+        );
+      }
+    }
+
+    window.addEventListener('message', onMessage);
+    return () => window.removeEventListener('message', onMessage);
+  }, [deskTheme, id, instanceId, open, persistCaptures, updateNodeDataTransient]);
+
+  const handleOpen = useCallback(() => {
+    setReady(false);
+    setOpen(true);
+    updateNodeDataTransient(id, { directorStatus: 'open' });
+  }, [id, updateNodeDataTransient]);
+
+  const handleClose = useCallback(() => {
+    setOpen(false);
+    setReady(false);
+    updateNodeDataTransient(id, { directorStatus: captureUrls.length ? 'ready' : 'idle' });
+  }, [captureUrls.length, id, updateNodeDataTransient]);
+
+  const handleExportFrame = useCallback(async () => {
+    const win = iframeRef.current?.contentWindow;
+    if (!win || !ready) {
+      showToast('请先打开并等待导演台就绪', 'error');
+      return;
+    }
+    setBusy('导出当前帧…');
+    try {
+      const result = (await requestDirectorAction(win, 'export.frame', {
+        position: 'current',
+        quality: '1080p',
+        fileName: `${(data.label as string) || 'director'}-frame.png`,
+      })) as { dataUrl?: string; fileName?: string } | undefined;
+
+      const dataUrl = result?.dataUrl;
+      if (!dataUrl?.startsWith('data:image/')) {
+        throw new Error('导演台未返回有效帧图');
+      }
+      await persistCaptures([{ dataUrl, fileName: result?.fileName || 'director-frame.png' }]);
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : '导出帧失败', 'error');
+    } finally {
+      setBusy(null);
+    }
+  }, [data.label, persistCaptures, ready, showToast]);
+
+  const handleExportVideo = useCallback(async () => {
+    const win = iframeRef.current?.contentWindow;
+    if (!win || !ready) {
+      showToast('请先打开并等待导演台就绪', 'error');
+      return;
+    }
+    setBusy('导出参考视频…');
+    try {
+      const result = (await requestDirectorAction(
+        win,
+        'export.video',
+        {
+          quality: '720p',
+          fps: 24,
+          fileName: `${(data.label as string) || 'director'}-ref.mp4`,
+        },
+        90_000,
+      )) as { dataUrl?: string; blobUrl?: string; fileName?: string } | undefined;
+
+      const mediaUrl = result?.dataUrl || result?.blobUrl;
+      if (!mediaUrl) {
+        throw new Error('导演台未返回参考视频（需先录制运镜轨迹）');
+      }
+
+      let videoUrl = mediaUrl;
+      let filePath: string | undefined;
+      if (currentProjectId && mediaUrl.startsWith('data:')) {
+        try {
+          const saved = await saveDataUrlToProjectData(
+            mediaUrl,
+            currentProjectId,
+            buildNodeFileName((data.label as string) || '导演台', 'mp4', 'director-ref'),
+          );
+          if (saved?.assetUrl) videoUrl = saved.assetUrl;
+          if (saved?.filePath) filePath = saved.filePath;
+        } catch {
+          /* keep raw */
+        }
+      }
+
+      updateNodeData(id, {
+        videoUrl,
+        filePath: filePath || (data.filePath as string | undefined),
+        status: 'success',
+        directorStatus: 'ready',
+        error: undefined,
+      });
+      showToast('参考视频已写入节点；图生视频请优先使用同步的截图/帧');
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : '导出视频失败', 'error');
+    } finally {
+      setBusy(null);
+    }
+  }, [currentProjectId, data.filePath, data.label, id, ready, showToast, updateNodeData]);
+
+  return (
+    <>
+      <div className="node-wrapper relative" style={{ width }}>
+        <NodeLabel
+          kind="ai-director"
+          label={displayLabel}
+          displayId={data.displayId as number | undefined}
+          nodeId={id}
+          onRename={handleRename}
+        />
+
+        <div
+          className={`node director-node ${selected ? 'selected' : ''} ${data.status === 'loading' ? 'loading' : ''}`}
+          style={{ width, height }}
+          onDoubleClick={handleOpen}
+        >
+          <div className="node-preview director-preview">
+            {captureUrls.length > 0 ? (
+              <div className="director-capture-grid">
+                {captureUrls.slice(-4).map((url, idx) => (
+                  <img
+                    key={`${idx}-${url.slice(0, 48)}`}
+                    src={url}
+                    alt=""
+                    className="director-capture-thumb"
+                    draggable={false}
+                  />
+                ))}
+              </div>
+            ) : (
+              <div className="node-preview-placeholder">
+                <Icon icon="mdi:video-3d" width={28} height={28} />
+                <span>3D 导演台</span>
+                <span className="text-node-edit-hint">双击打开 · 同步截图后连线生视频</span>
+              </div>
+            )}
+          </div>
+
+          <div className="director-node-actions nodrag nopan">
+            <button type="button" className="director-node-btn primary" onClick={handleOpen}>
+              打开导演台
+            </button>
+            <span className="director-node-meta">
+              {captureUrls.length > 0 ? `${captureUrls.length} 张参考图` : '未同步截图'}
+            </span>
+          </div>
+
+          {data.error && <NodeError nodeId={id} message={String(data.error)} />}
+
+          <Handle type="target" position={Position.Left} id="left" className="node-handle handle-target handle-director">
+            <GooeyBtn className="gooey-btn-left" hue={280} />
+          </Handle>
+          <Handle type="source" position={Position.Right} id="right" className="node-handle handle-source handle-director">
+            <GooeyBtn className="gooey-btn-right" hue={280} />
+          </Handle>
+        </div>
+
+        <ResizeHandle
+          nodeId={id}
+          currentWidth={width}
+          currentHeight={height}
+          minWidth={260}
+          minHeight={180}
+          onResizeStart={commitToHistory}
+          onResizeEnd={commitToHistory}
+          onResize={handleResize}
+        />
+      </div>
+
+      <FullscreenOverlay
+        isOpen={open}
+        onClose={handleClose}
+        title={`${displayLabel} · ${getDirectorDeskOrigin()}`}
+        panelWidth="min(96vw, 1280px)"
+        bodyClassName="director-overlay-body"
+      >
+        <div className="director-overlay-root">
+          <div className="director-overlay-toolbar nodrag nopan">
+            <span className={`director-ready-dot ${ready ? 'is-ready' : ''}`} />
+            <span>{ready ? '已连接' : '连接中…'}</span>
+            <span className="director-overlay-hint">
+              在导演台内运镜后，点「发送截图到宿主」或下方「同步当前帧」；再连线到「生成视频」节点
+            </span>
+            <div className="director-overlay-actions">
+              <button
+                type="button"
+                className="director-node-btn"
+                disabled={!ready || !!busy}
+                onClick={() => void handleExportFrame()}
+              >
+                同步当前帧
+              </button>
+              <button
+                type="button"
+                className="director-node-btn"
+                disabled={!ready || !!busy}
+                onClick={() => void handleExportVideo()}
+              >
+                导出参考视频
+              </button>
+              <button type="button" className="director-node-btn" onClick={handleClose}>
+                关闭
+              </button>
+            </div>
+          </div>
+          {busy && <div className="director-overlay-busy">{busy}</div>}
+          <iframe
+            ref={iframeRef}
+            className="director-overlay-iframe"
+            title="3D 导演台"
+            src={iframeSrc}
+            allow="clipboard-read; clipboard-write; fullscreen"
+          />
+        </div>
+      </FullscreenOverlay>
+    </>
+  );
+}
+
+export default memo(DirectorDeskNode);

--- a/src/components/nodes/shared/ConnectedNodesPreview.tsx
+++ b/src/components/nodes/shared/ConnectedNodesPreview.tsx
@@ -77,10 +77,15 @@ export default function ConnectedNodesPreview({ nodeId, onInsertMention }: Conne
       .filter((n) => n.id !== nodeId && n.type !== 'group' && sourceIds.has(n.id))
       .map((n) => {
         const data = n.data as BaseNodeData;
-        const outputType = data.imageUrl
+        const isDirector = data.type === 'ai-director' || n.type === 'ai-director';
+        const directorThumb = isDirector
+          ? ((data.imageUrl as string | undefined)
+            || (Array.isArray(data.directorCaptureUrls) ? (data.directorCaptureUrls as string[])[0] : undefined))
+          : undefined;
+        const outputType = (data.imageUrl || directorThumb)
           ? 'image' : data.videoUrl ? 'video' : data.audioUrl ? 'audio' : 'text';
         const thumbnailUrl = outputType === 'image'
-          ? (localAssetUrl(data.filePath as string | undefined) || (data.thumbnailUrl as string) || data.imageUrl || undefined)
+          ? (localAssetUrl(data.filePath as string | undefined) || (data.thumbnailUrl as string) || data.imageUrl || directorThumb || undefined)
           : outputType === 'video'
           ? ((data.thumbnailUrl as string) || undefined) : undefined;
         const textSnippet = outputType === 'text' && data.output

--- a/src/hooks/useConnectionDropMenu.ts
+++ b/src/hooks/useConnectionDropMenu.ts
@@ -65,6 +65,10 @@ const CONNECTION_MENU_MAP: Record<string, ConnectionMenuOption[]> = {
     { label: '生成动画', type: 'ai-animation' },
     { label: '生成360全景图', type: 'ai-panorama' },
   ],
+  'ai-director': [
+    { label: '生成图像', type: 'ai-image' },
+    { label: '生成视频', type: 'ai-video' },
+  ],
   'ai-video': [],
   'ai-audio': [
     { label: '生成文本', type: 'ai-text' },
@@ -146,8 +150,21 @@ export function useConnectionDropMenu(smoothLine: boolean) {
       const srcRight = srcX + srcWidth;
 
       const isAnimation = option.type === 'ai-animation';
-      const newWidth = isAnimation ? 320 : option.type === 'ai-audio' ? 260 : option.type === 'ai-panorama' ? 300 : 280;
-      const newHeight = isAnimation ? 358 : option.type === 'ai-audio' ? 140 : option.type === 'ai-image' ? 158 : option.type === 'ai-panorama' ? 200 : option.type === 'ai-markdown' ? 200 : 160;
+      const isDirector = option.type === 'ai-director';
+      const newWidth = isAnimation || isDirector ? 320 : option.type === 'ai-audio' ? 260 : option.type === 'ai-panorama' ? 300 : 280;
+      const newHeight = isDirector
+        ? 240
+        : isAnimation
+          ? 358
+          : option.type === 'ai-audio'
+            ? 140
+            : option.type === 'ai-image'
+              ? 158
+              : option.type === 'ai-panorama'
+                ? 200
+                : option.type === 'ai-markdown'
+                  ? 200
+                  : 160;
 
       // Determine handle direction based on position relative to source
       const releasedRight = flowPos.x >= srcRight + 10;
@@ -207,7 +224,12 @@ export function useConnectionDropMenu(smoothLine: boolean) {
             aspectRatio: '1:1',
             imageSize: '2K',
           } : {}),
-          ...(defaultModel ? { model: defaultModel.model, provider: defaultModel.provider } : {}),
+          ...(isDirector ? {
+            role: 'source' as const,
+            directorStatus: 'idle' as const,
+            directorCaptureUrls: [] as string[],
+          } : {}),
+          ...(defaultModel && !isDirector ? { model: defaultModel.model, provider: defaultModel.provider } : {}),
         },
       };
       const edge: Edge = {

--- a/src/index.css
+++ b/src/index.css
@@ -12,6 +12,7 @@
 @import './styles/nodes-animation.css';
 @import './styles/nodes-panorama.css';
 @import './styles/nodes-storyboard.css';
+@import './styles/nodes-director.css';
 @import './styles/nodes-group.css';
 @import './styles/prompt.css';
 @import './styles/preset-manager.css';

--- a/src/services/ai/generateVideo.ts
+++ b/src/services/ai/generateVideo.ts
@@ -15,6 +15,43 @@ import { pollTask } from '../pollTask';
 import { runConfiguredModelProtocol } from './modelProtocolRuntime';
 import { normalizeFrames8n1 } from './modelProtocol';
 import { savePendingTask, updatePendingTask, removePendingTask, registerNodePolling, cleanupNodePolling } from '../pollManager';
+import { collectDirectorImageUrls } from '../directorDeskService';
+import type { BaseNodeData } from '../../types';
+
+/** 收集连入当前视频节点的参考图（含 3D 导演台截图） */
+function collectConnectedReferenceImages(nodeId: string | undefined): string[] {
+  if (!nodeId) return [];
+  const { nodes, edges } = useAppStore.getState();
+  const sourceIds = edges.filter((e) => e.target === nodeId).map((e) => e.source);
+  const urls: string[] = [];
+  const seen = new Set<string>();
+  const push = (url: unknown) => {
+    if (typeof url !== 'string') return;
+    const u = url.trim();
+    if (!u || seen.has(u)) return;
+    seen.add(u);
+    urls.push(u);
+  };
+  for (const sid of sourceIds) {
+    const node = nodes.find((n) => n.id === sid);
+    if (!node) continue;
+    const data = node.data as BaseNodeData;
+    const type = (data.type as string) || node.type || '';
+    if (type === 'ai-director') {
+      for (const u of collectDirectorImageUrls(data)) push(u);
+      continue;
+    }
+    if (
+      type === 'ai-image'
+      || type === 'source-image'
+      || type === 'ai-panorama'
+      || type === 'ai-storyboard'
+    ) {
+      push(data.imageUrl || data.thumbnailUrl);
+    }
+  }
+  return urls;
+}
 
 export async function generateVideo(params: AIVideoGenParams): Promise<{ url: string }> {
   const { prompt: rawPrompt, model, provider } = params;
@@ -30,11 +67,16 @@ export async function generateVideo(params: AIVideoGenParams): Promise<{ url: st
   // 即梦视频：无参考图 → text2video；有参考图 → image2video
   if (provider === 'dreamina') {
     const { prompt: dreaminaPrompt, imageUrls } = await resolvePromptWithImageRefs(rawPrompt);
+    const connected = collectConnectedReferenceImages(params.nodeId);
+    const merged = [...imageUrls];
+    for (const u of connected) {
+      if (!merged.includes(u)) merged.push(u);
+    }
     if (!dreaminaPrompt.trim()) throw new Error('提示词不能为空');
     return generateDreaminaVideo({
       prompt: dreaminaPrompt,
       model,
-      imageUrls,
+      imageUrls: merged,
       nodeId: params.nodeId,
       ratio: params.seedanceRatio,
       duration: params.seedanceDuration,
@@ -57,7 +99,12 @@ export async function generateVideo(params: AIVideoGenParams): Promise<{ url: st
     const modelName = extractModelName(model, provider);
     if (isApimartSeedanceModel(modelName)) {
       const { prompt: resolvedPrompt, imageUrls } = await resolvePromptWithImageRefs(rawPrompt);
-      if (!resolvedPrompt.trim() && imageUrls.length === 0) {
+      const connected = collectConnectedReferenceImages(params.nodeId);
+      const merged = [...imageUrls];
+      for (const u of connected) {
+        if (!merged.includes(u)) merged.push(u);
+      }
+      if (!resolvedPrompt.trim() && merged.length === 0) {
         throw new Error('提示词不能为空');
       }
       return generateApimartVideo(apiKey, baseUrl, modelName, resolvedPrompt, params.nodeId, {
@@ -65,7 +112,7 @@ export async function generateVideo(params: AIVideoGenParams): Promise<{ url: st
         ratio: params.seedanceRatio,
         duration: params.seedanceDuration,
         generateAudio: params.generateAudio,
-        imageUrls,
+        imageUrls: merged,
       });
     }
     return generateApimartVideo(apiKey, baseUrl, modelName, prompt, params.nodeId);

--- a/src/services/ai/promptResolver.ts
+++ b/src/services/ai/promptResolver.ts
@@ -126,8 +126,17 @@ export async function resolvePromptToChatContent(rawPrompt: string): Promise<{
       parts.push(match[0]);
     } else {
       const nodeType = (node.data.type as string) || '';
-      if (nodeType === 'ai-image' || nodeType === 'source-image' || nodeType === 'ai-storyboard') {
-        const imageUrl = node.data.imageUrl as string | undefined;
+      if (
+        nodeType === 'ai-image'
+        || nodeType === 'source-image'
+        || nodeType === 'ai-storyboard'
+        || nodeType === 'ai-director'
+        || nodeType === 'ai-panorama'
+      ) {
+        const imageUrl = (
+          (node.data.imageUrl as string | undefined)
+          || (node.data.thumbnailUrl as string | undefined)
+        );
         if (typeof imageUrl === 'string' && imageUrl.trim()) {
           const key = `node:${nodeId}`;
           let idx = imageKeyToIndex.get(key);
@@ -142,6 +151,19 @@ export async function resolvePromptToChatContent(rawPrompt: string): Promise<{
             });
           }
           parts.push(`图片${idx}`);
+        }
+        if (nodeType === 'ai-director' && Array.isArray(node.data.directorCaptureUrls)) {
+          for (const [i, url] of (node.data.directorCaptureUrls as string[]).entries()) {
+            if (typeof url !== 'string' || !url.trim() || url === imageUrl) continue;
+            const key = `node:${nodeId}:cap:${i}`;
+            let idx = imageKeyToIndex.get(key);
+            if (idx === undefined) {
+              idx = imageEntries.length + 1;
+              imageKeyToIndex.set(key, idx);
+              imageEntries.push({ url });
+            }
+            parts.push(`图片${idx}`);
+          }
         }
       } else {
         const output = node.data.output as string | undefined;
@@ -267,9 +289,33 @@ export async function resolvePromptWithImageRefs(rawPrompt: string): Promise<{ p
 
     const nodeType = (node.data.type as string) || '';
 
-    if (nodeType === 'ai-image' || nodeType === 'source-image' || nodeType === 'ai-storyboard') {
-      const imageUrl = node.data.imageUrl as string | undefined;
-      if (typeof imageUrl !== 'string' || !imageUrl.trim()) return '';
+    if (
+      nodeType === 'ai-image'
+      || nodeType === 'source-image'
+      || nodeType === 'ai-storyboard'
+      || nodeType === 'ai-director'
+      || nodeType === 'ai-panorama'
+    ) {
+      const imageUrl = (
+        (node.data.imageUrl as string | undefined)
+        || (node.data.thumbnailUrl as string | undefined)
+      );
+      if (typeof imageUrl !== 'string' || !imageUrl.trim()) {
+        if (nodeType === 'ai-director' && Array.isArray(node.data.directorCaptureUrls)) {
+          const first = (node.data.directorCaptureUrls as string[]).find((u) => typeof u === 'string' && u.trim());
+          if (first) {
+            const key = `node:${rawNodeId}:cap0`;
+            let idx = imageKeyToIndex.get(key);
+            if (idx === undefined) {
+              idx = imageEntries.length + 1;
+              imageKeyToIndex.set(key, idx);
+              imageEntries.push({ url: first });
+            }
+            return `图片${idx}`;
+          }
+        }
+        return '';
+      }
       const key = `node:${rawNodeId}`;
       let idx = imageKeyToIndex.get(key);
       if (idx === undefined) {
@@ -281,6 +327,16 @@ export async function resolvePromptWithImageRefs(rawPrompt: string): Promise<{ p
           annotation: (node.data.annotation as string | undefined) || undefined,
           filePath: (node.data.filePath as string | undefined) || undefined,
         });
+      }
+      if (nodeType === 'ai-director' && Array.isArray(node.data.directorCaptureUrls)) {
+        for (const [i, url] of (node.data.directorCaptureUrls as string[]).entries()) {
+          if (typeof url !== 'string' || !url.trim() || url === imageUrl) continue;
+          const capKey = `node:${rawNodeId}:cap:${i}`;
+          if (!imageKeyToIndex.has(capKey)) {
+            imageKeyToIndex.set(capKey, imageEntries.length + 1);
+            imageEntries.push({ url });
+          }
+        }
       }
       return `图片${idx}`;
     }

--- a/src/services/directorDeskService.ts
+++ b/src/services/directorDeskService.ts
@@ -1,0 +1,155 @@
+/**
+ * 3D 导演台（xiaozangao/3d-director-desk）宿主通信
+ * - 本地默认：http://127.0.0.1:5173
+ * - 通过 iframe + postMessage 对接，截图/导出回写画布节点
+ */
+
+export const DIRECTOR_DESK_ORIGIN_KEY = 'canvas-director-desk-origin';
+export const DEFAULT_DIRECTOR_DESK_ORIGIN = 'http://127.0.0.1:5173';
+
+export type DirectorCaptureItem = {
+  dataUrl: string;
+  fileName: string;
+};
+
+export type DirectorExtensionAction =
+  | 'capabilities.get'
+  | 'project.get'
+  | 'timeline.get'
+  | 'export.frame'
+  | 'export.video'
+  | 'plugin.result.submit'
+  | 'plugin.results.list';
+
+export function getDirectorDeskOrigin(): string {
+  try {
+    const saved = localStorage.getItem(DIRECTOR_DESK_ORIGIN_KEY)?.trim();
+    if (saved) return saved.replace(/\/+$/, '');
+  } catch {
+    /* ignore */
+  }
+  return DEFAULT_DIRECTOR_DESK_ORIGIN;
+}
+
+export function setDirectorDeskOrigin(origin: string) {
+  const normalized = origin.trim().replace(/\/+$/, '');
+  if (!normalized) {
+    localStorage.removeItem(DIRECTOR_DESK_ORIGIN_KEY);
+    return;
+  }
+  localStorage.setItem(DIRECTOR_DESK_ORIGIN_KEY, normalized);
+}
+
+export function getHostOriginForDirector(): string {
+  try {
+    return window.location.origin;
+  } catch {
+    return 'http://localhost:1420';
+  }
+}
+
+export function buildDirectorDeskIframeSrc(instanceId: string, theme: 'dark' | 'light' = 'dark'): string {
+  const origin = getDirectorDeskOrigin();
+  const hostOrigin = encodeURIComponent(getHostOriginForDirector());
+  const id = encodeURIComponent(instanceId);
+  return `${origin}/?instanceId=${id}&theme=${theme}&hostOrigin=${hostOrigin}`;
+}
+
+export function isDirectorDeskMessage(event: MessageEvent, expectedOrigin?: string): boolean {
+  const origin = expectedOrigin ?? getDirectorDeskOrigin();
+  return event.origin === origin;
+}
+
+export function requestDirectorAction(
+  target: Window,
+  action: DirectorExtensionAction,
+  options?: Record<string, unknown>,
+  timeoutMs = 30_000,
+): Promise<unknown> {
+  const requestId = crypto.randomUUID();
+  const directorOrigin = getDirectorDeskOrigin();
+
+  return new Promise((resolve, reject) => {
+    const timer = window.setTimeout(() => {
+      window.removeEventListener('message', onMessage);
+      reject(new Error(`3D 导演台请求超时：${action}`));
+    }, timeoutMs);
+
+    function onMessage(event: MessageEvent) {
+      if (!isDirectorDeskMessage(event, directorOrigin)) return;
+      if (event.data?.type !== 'storyai:director-desk:response') return;
+      const payload = event.data.payload;
+      if (!payload || payload.requestId !== requestId) return;
+      window.clearTimeout(timer);
+      window.removeEventListener('message', onMessage);
+      if (!payload.ok) {
+        reject(new Error(payload.error?.message || `3D 导演台请求失败：${action}`));
+        return;
+      }
+      resolve(payload.data);
+    }
+
+    window.addEventListener('message', onMessage);
+    target.postMessage(
+      {
+        type: 'storyai:director-desk:request',
+        payload: { requestId, action, ...(options ? { options } : {}) },
+      },
+      directorOrigin,
+    );
+  });
+}
+
+export function postDirectorSession(
+  target: Window,
+  payload: { instanceId: string; theme?: 'dark' | 'light' },
+) {
+  target.postMessage(
+    {
+      type: 'storyai:director-desk-session',
+      payload,
+    },
+    getDirectorDeskOrigin(),
+  );
+}
+
+export function postDirectorPanorama(
+  target: Window,
+  payload: {
+    edgeId?: string;
+    sourceNodeId?: string;
+    imageUrl: string;
+    fileName?: string;
+  },
+) {
+  target.postMessage(
+    {
+      type: 'storyai:director-desk-panorama',
+      payload,
+    },
+    getDirectorDeskOrigin(),
+  );
+}
+
+/** 从节点数据中收集可用于图生视频的参考图 URL 列表 */
+export function collectDirectorImageUrls(data: {
+  imageUrl?: unknown;
+  directorCaptureUrls?: unknown;
+  directorCaptureFilePaths?: unknown;
+}): string[] {
+  const urls: string[] = [];
+  const seen = new Set<string>();
+  const push = (value: unknown) => {
+    if (typeof value !== 'string') return;
+    const url = value.trim();
+    if (!url || seen.has(url)) return;
+    seen.add(url);
+    urls.push(url);
+  };
+
+  push(data.imageUrl);
+  if (Array.isArray(data.directorCaptureUrls)) {
+    for (const item of data.directorCaptureUrls) push(item);
+  }
+  return urls;
+}

--- a/src/services/nodeReferenceService.ts
+++ b/src/services/nodeReferenceService.ts
@@ -12,9 +12,13 @@ export function resolveNodeReferences(value: string): string {
     // 文本节点的输出在 data.output 中
     const output = node.data.output as string | undefined;
     if (typeof output === 'string' && output.trim()) return output;
-    // 图片节点的输出在 data.imageUrl 中
+    // 图片 / 导演台节点的输出在 data.imageUrl 或 directorCaptureUrls 中
     const imageUrl = node.data.imageUrl as string | undefined;
     if (typeof imageUrl === 'string' && imageUrl.trim()) return imageUrl;
+    if (Array.isArray(node.data.directorCaptureUrls)) {
+      const first = (node.data.directorCaptureUrls as string[]).find((u) => typeof u === 'string' && u.trim());
+      if (first) return first;
+    }
     // 视频 / 音频同理
     const videoUrl = node.data.videoUrl as string | undefined;
     if (typeof videoUrl === 'string' && videoUrl.trim()) return videoUrl;

--- a/src/styles/nodes-director.css
+++ b/src/styles/nodes-director.css
@@ -1,0 +1,148 @@
+/* ── 3D 导演台节点 ── */
+
+.director-node {
+  overflow: hidden;
+}
+
+.director-preview {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: color-mix(in srgb, var(--node-director) 8%, transparent);
+}
+
+.director-capture-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 4px;
+  width: 100%;
+  height: 100%;
+  padding: 8px;
+  box-sizing: border-box;
+}
+
+.director-capture-thumb {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.25);
+  min-height: 48px;
+}
+
+.director-node-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 10px;
+  border-top: 1px solid var(--theme-border);
+  background: color-mix(in srgb, var(--theme-surface) 70%, transparent);
+}
+
+.director-node-btn {
+  appearance: none;
+  border: 1px solid color-mix(in srgb, var(--node-director) 40%, transparent);
+  background: color-mix(in srgb, var(--node-director) 18%, transparent);
+  color: var(--theme-text);
+  border-radius: 8px;
+  padding: 5px 10px;
+  font-size: 12px;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, opacity 0.15s ease;
+}
+
+.director-node-btn:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--node-director) 30%, transparent);
+  border-color: color-mix(in srgb, var(--node-director) 60%, transparent);
+}
+
+.director-node-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.director-node-btn.primary {
+  background: color-mix(in srgb, var(--node-director) 35%, transparent);
+  font-weight: 600;
+}
+
+.director-node-meta {
+  font-size: 11px;
+  color: var(--theme-text-secondary);
+  white-space: nowrap;
+}
+
+.director-overlay-body {
+  padding: 0 !important;
+  display: flex;
+  flex-direction: column;
+  min-height: min(82vh, 820px);
+}
+
+.director-overlay-root {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: min(82vh, 820px);
+  background: #0b0b12;
+}
+
+.director-overlay-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  padding: 10px 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  color: #e8e8f0;
+  font-size: 12px;
+  background: rgba(20, 20, 32, 0.96);
+}
+
+.director-overlay-hint {
+  flex: 1;
+  min-width: 180px;
+  color: rgba(232, 232, 240, 0.65);
+}
+
+.director-overlay-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.director-ready-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #f59e0b;
+  box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.2);
+}
+
+.director-ready-dot.is-ready {
+  background: #22c55e;
+  box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.2);
+}
+
+.director-overlay-busy {
+  padding: 6px 12px;
+  font-size: 12px;
+  color: #fde68a;
+  background: rgba(120, 53, 15, 0.45);
+}
+
+.director-overlay-iframe {
+  flex: 1;
+  width: 100%;
+  min-height: 0;
+  border: 0;
+  background: #000;
+}
+
+.handle-director {
+  /* color via gooey hue */
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,6 +14,7 @@ export type NodeType =
   | 'ai-panorama'
   | 'ai-markdown'
   | 'ai-storyboard'
+  | 'ai-director'
   | 'source-image'
   | 'source-video'
   | 'source-audio'
@@ -116,6 +117,11 @@ export interface BaseNodeData {
   storyboardColPositions?: number[];    // 自定义竖线位置百分比（有序，不含 0/100），非均匀裁切时使用
   storyboardExtracted?: boolean[];      // 各格是否已被拖出提取（行优先），已提取的格显示空占位
   storyboardOverrides?: (StoryboardCellOverride | null)[]; // 各格被拖入的图片（覆盖源图裁片显示）
+  // ── 3D 导演台（ai-director）──
+  directorInstanceId?: string;           // 导演台 localStorage 隔离实例 ID
+  directorStatus?: 'idle' | 'open' | 'ready';
+  directorCaptureUrls?: string[];        // 从导演台同步的截图 URL 列表
+  directorCaptureFilePaths?: string[];   // 对应本地路径
   [key: string]: unknown;
 }
 
@@ -425,6 +431,7 @@ export const NODE_TYPE_CONFIG: Record<string, NodeTypeVisualConfig> = {
   'ai-panorama': { icon: 'mdi:panorama',                  color: 'text-cyan-400',    bg: 'bg-cyan-500/15',    label: '生成360全景' },
   'ai-markdown': { icon: 'mdi:language-markdown-outline', color: 'text-purple-400',  bg: 'bg-purple-500/15',  label: 'Markdown' },
   'ai-storyboard': { icon: 'mdi:grid',                    color: 'text-pink-400',    bg: 'bg-pink-500/15',    label: '宫格分镜' },
+  'ai-director':   { icon: 'mdi:video-3d',                color: 'text-violet-400',  bg: 'bg-violet-500/15',  label: '3D 导演台' },
 };
 
 /** 获取节点类型视觉配置，未匹配时返回灰色兜底 */


### PR DESCRIPTION
## 摘要

新增 **3D 导演台** 画布节点（`ai-director`），嵌入本地 [3d-director-desk](https://github.com) 服务（默认 `http://127.0.0.1:5173`），用于运镜预演；截图/导出可回写到节点，并作为下游生图/生视频的参考图。

## 改动要点

- 新节点 `DirectorDeskNode` + `directorDeskService`（iframe postMessage）
- 类型 `ai-director` 与节点字段（`directorCaptureUrls` 等）
- 注册到 Canvas / 侧栏加号 / 右键 NodeMenu / 连线落点菜单
- `@` 与视频生成可消费导演台截图
- 开发脚本：`npm run director` / `dev` / `tauri` 可联动启动导演台（`tauri:raw` 保持原 tauri）

## 使用方式

1. 本机先有可用的 3D 导演台前端（默认 5173）
2. 画布左侧 **+** → **3D 导演台**
3. 节点内打开导演台，截图后连到视频/图像节点作参考

## 说明

- 与 #4（短剧资产 / 风格母图）独立，便于单独 review
- 依赖外部导演台进程；未启动时节点会提示连接失败，不影响其它节点