### PR TITLE
fix: CameraStudio 派生节点携带 workflowId 并正确注入 img2img 参考图

### DIFF
--- a/src/components/nodes/shared/toolbar/presetAction.ts
+++ b/src/components/nodes/shared/toolbar/presetAction.ts
@@ -202,6 +202,11 @@ export function createPresetNode(
     status: 'idle',
     model: (resolved.override?.model || effectiveModel?.model || sourceNode.data.model) as string,
     provider: (resolved.override?.provider || effectiveModel?.provider || sourceNode.data.provider) as string,
+    // ComfyUI 工作流节点必须带上 workflowId / workflowInputs，
+    // 否则派生节点（如小洛摄影棚生成的「摄影机视角」）会丢失工作流，
+    // 在 generateImage 中误入通用模型分支并报「未配置 comfyui 的 API Key」。
+    workflowId: sourceNode.data.workflowId,
+    workflowInputs: sourceNode.data.workflowInputs,
     imageSize: resolved.override?.imageSize ?? sourceNode.data.imageSize,
     aspectRatio: resolved.override?.aspectRatio ?? sourceNode.data.aspectRatio,
     nodeWidth,

--- a/src/services/comfyWorkflowService.ts
+++ b/src/services/comfyWorkflowService.ts
@@ -961,7 +961,9 @@ async function submitComfyUIWorkflow(
   // 没 @ 图片/视频节点时，把提示词框里引用的同类媒体送进默认节点
   const hasPromptMedia = Boolean(promptMedia.imageUrls?.length || promptMedia.videoUrls?.length);
   for (const kind of ['image', 'video'] as const) {
-    const defaultNodeId = defaultNodeFor(kind);
+    // 工作流未配置默认 IO 节点时，兜底取第一个同类型节点，
+    // 避免 prompt 里 @ 的参考图因找不到注入目标而静默丢弃（LoadImage 沿用示例文件名）。
+    const defaultNodeId = defaultNodeFor(kind) ?? ioNodes.find((io) => io.type === kind)?.nodeId;
     if (!defaultNodeId) continue;
     const urls = kind === 'image' ? promptMedia.imageUrls : promptMedia.videoUrls;
     await injectDefaultMediaIntoWorkflow(

--- a/src/services/generationService.ts
+++ b/src/services/generationService.ts
@@ -100,9 +100,10 @@ export async function executeGeneration(
       const result = await generateImage({
         prompt: effectivePrompt, model: nodeModel, provider: nodeProvider,
         imageSize, aspectRatio, nodeId,
-        // 透传工作流与参考图：executeGeneration 由 Toolbar / 小洛摄影棚等快捷入口触发，
-        // 此前未透传 workflowId / workflowInputs / image_urls，导致 ComfyUI 工作流
-        // 无法执行（误报「未配置 comfyui 的 API Key」）且 img2img 参考图丢失。
+        // 透传工作流：executeGeneration 由 Toolbar / 小洛摄影棚等快捷入口触发，
+        // 此前未透传 workflowId / workflowInputs，导致 ComfyUI 工作流
+        // 无法执行（误报「未配置 comfyui 的 API Key」）。
+        // 参考图仍按既有约定由 prompt 中 @{节点} 引用显式传入，不自动携带节点旧图。
         workflowId: data.workflowId,
         workflowInputs: data.workflowInputs,
       });

--- a/src/services/generationService.ts
+++ b/src/services/generationService.ts
@@ -99,6 +99,14 @@ export async function executeGeneration(
       const result = await generateImage({
         prompt: effectivePrompt, model: nodeModel, provider: nodeProvider,
         imageSize, aspectRatio, nodeId,
+        // 透传工作流与参考图：executeGeneration 由 Toolbar / 小洛摄影棚等快捷入口触发，
+        // 此前未透传 workflowId / workflowInputs / image_urls，导致 ComfyUI 工作流
+        // 无法执行（误报「未配置 comfyui 的 API Key」）且 img2img 参考图丢失。
+        workflowId: data.workflowId,
+        workflowInputs: data.workflowInputs,
+        image_urls: (data.imageUrl || data.thumbnailUrl)
+          ? [(data.imageUrl || data.thumbnailUrl) as string]
+          : undefined,
       });
       if (!isStillCurrentSubmission()) return { success: false, message: '任务已取消' };
 

--- a/src/services/generationService.ts
+++ b/src/services/generationService.ts
@@ -84,6 +84,7 @@ export async function executeGeneration(
         const batch = await generateImagesBatch({
           prompt: effectivePrompt, model: nodeModel, provider: nodeProvider,
           imageSize, aspectRatio, nodeId,
+          workflowId: data.workflowId,
         }, batchCount);
         if (!isStillCurrentSubmission()) return { success: false, message: '任务已取消' };
         await applyImageBatchResults({
@@ -104,9 +105,6 @@ export async function executeGeneration(
         // 无法执行（误报「未配置 comfyui 的 API Key」）且 img2img 参考图丢失。
         workflowId: data.workflowId,
         workflowInputs: data.workflowInputs,
-        image_urls: (data.imageUrl || data.thumbnailUrl)
-          ? [(data.imageUrl || data.thumbnailUrl) as string]
-          : undefined,
       });
       if (!isStillCurrentSubmission()) return { success: false, message: '任务已取消' };
 


### PR DESCRIPTION
## Summary
Fixes the CameraStudio (小洛摄影棚) derived-node bugs when targeting ComfyUI workflows:

1. **派生节点丢失 `workflowId` / `workflowInputs`** — `createPresetNode` copied `model`/`provider` but not the workflow fields, so a derived node (「摄影机视角」/「摄影棚打光」) with `provider='comfyui'` had no `workflowId`; `generateImage` fell into the generic-model branch and wrongly reported 「未配置 comfyui 的 API Key」.
2. **`executeGeneration` 未透传工作流** — the Toolbar / CameraStudio path called `generateImage` without `workflowId` / `workflowInputs`, so ComfyUI workflows could never run from these entry points. The batch branch now also forwards `workflowId` so 「工作流暂不支持批量生成」 is reported instead of the misleading API-Key error.
3. **无默认 IO 节点时参考图兜底缺失** — `injectDefaultMediaIntoWorkflow` only ran when `defaultNodes.<kind>` existed; workflows without a configured default image node dropped prompt-referenced images entirely (LoadImage kept the workflow's own sample file, e.g. `example.png`). Now falls back to the first IO node of that type.

### Design note
Reference images are intentionally **not** auto-forwarded from the node's own previous image (`image_urls`): AI Canvas's convention is that references are passed explicitly via `@{nodeId}` mentions in the prompt (resolved by `resolvePromptWithImageRefs`). Auto-forwarding would silently turn a plain text-to-image re-run into an img2img request on regular providers. The CameraStudio flow already embeds `@{sourceNodeId}` in the derived node's prompt, so the reference image reaches the workflow through the prompt-mention channel combined with fix #3.

## Changes
- `src/components/nodes/shared/toolbar/presetAction.ts` — `createPresetNode` now copies `workflowId` / `workflowInputs` into the derived node data.
- `src/services/generationService.ts` — `executeGeneration` now passes `workflowId` / `workflowInputs` into `generateImage` (single & batch).
- `src/services/comfyWorkflowService.ts` — `defaultNodeFor(kind)` falls back to the first IO node of the same type.

## Test plan
- CameraStudio → 生成图片 with a ComfyUI img2img workflow: derived node keeps the workflow and reference image is uploaded into `LoadImage`.
- Re-generate an already-generated image node with a regular provider: behavior unchanged (no implicit reference image).
- Existing non-ComfyUI providers unaffected (extra params are simply forwarded).
