### PR TITLE
feat(video): 视频节点多节点并行生成（在此节点生成开关 + 数量滑块 + 占位节点并行生成）

### DIFF
--- a/src/components/nodes/AINodeDialog.tsx
+++ b/src/components/nodes/AINodeDialog.tsx
@@ -1,7 +1,7 @@
 /**
  * AINodeDialog AI 生成弹窗 — 点击节点后弹出的浮动面板，包含 Prompt 输入、模型选择、参数配置、生成按钮
  */
-import { memo, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useLayoutEffect, useRef } from 'react';
 import { convertFileSrc } from '@tauri-apps/api/core';
 import { useShallow } from 'zustand/react/shallow';
 import { generateId, useAppStore } from '../../store/useAppStore';
@@ -64,8 +64,6 @@ function AINodeDialog() {
   const panelRef = useRef<HTMLDivElement>(null);
   const previewRef = useRef<HTMLDivElement>(null);
   const cancellingNodeIdsRef = useRef(new Set<string>());
-  // 不勾选「在此节点生成」时，待选的新节点数量（null=不显示选择框；1-4 选中后执行）
-  const [pendingVideoCount, setPendingVideoCount] = useState<number | null>(null);
 
   useLayoutEffect(() => {
     const panel = panelRef.current;
@@ -275,10 +273,136 @@ function AINodeDialog() {
     [updateContinuousNodeData]
   );
 
-  // 调用选中模型生成（文本 or 图片）
+    /**
+   * 不勾选「在此节点生成」：串行生成 count 条视频，每条落到源节点右侧新建的视频节点并自动连线。
+   * 一次 addNodesWithEdges 提交全部节点与连线（单个历史快照）。
+   */
+  const runVideoToNewNodes = useCallback(async (count: number) => {
+    const store = useAppStore.getState();
+    const submittingNodeId = activeNodeId;
+    const submittingProjectId = currentProjectId;
+    if (!submittingNodeId || !submittingProjectId) return;
+    const sourceNode = store.nodes.find((n) => n.id === submittingNodeId);
+    if (!sourceNode) return;
+    const latestData = sourceNode.data as BaseNodeData;
+    const rawPrompt = latestData.prompt ?? '';
+    const nodeModel = latestData.model;
+    const nodeProvider = latestData.provider;
+    const nodeLabel = latestData.label ?? '视频';
+    if (!nodeModel || !nodeProvider) {
+      showToast('请先在底部模型选择器中选择一个模型', 'error');
+      return;
+    }
+    const projectSettings = store.projects.find((p) => p.id === submittingProjectId)?.settings;
+    const projectPrompt = resolveProjectGenerationPrompt({
+      prompt: rawPrompt,
+      data: latestData,
+      settings: projectSettings,
+      customStyles: store.customStyles,
+    });
+    const cameraPrompt = buildGenerationCameraPrompt(latestData.cameraSettings);
+    const effectivePrompt = cameraPrompt
+      ? `${projectPrompt}\n\nCamera settings: ${cameraPrompt}.`
+      : projectPrompt;
+    const videoFps = Number(latestData.videoFps) || 24;
+    const seedanceDuration = resolveVideoDurationSeconds(
+      latestData.seedanceDuration,
+      latestData.videoFrames,
+      videoFps,
+    );
+    const videoFrames = videoFramesFromDuration(seedanceDuration, videoFps);
+    const params = {
+      prompt: effectivePrompt,
+      model: nodeModel,
+      provider: nodeProvider,
+      videoResolution: Number(latestData.videoResolution) || 832,
+      videoFps,
+      videoFrames,
+      seedanceResolution: (latestData.seedanceResolution as string) || '720p',
+      seedanceRatio: (latestData.seedanceRatio as string) || '16:9',
+      seedanceDuration,
+      generateAudio: latestData.generateAudio,
+      workflowId: latestData.workflowId,
+      workflowInputs: latestData.workflowInputs,
+      nodeId: submittingNodeId,
+    };
+    const isStill = () => {
+      const s = useAppStore.getState();
+      return s.currentProjectId === submittingProjectId
+        && s.nodes.some((n) => n.id === submittingNodeId);
+    };
+    updateNodeDataTransient(submittingNodeId, { status: 'loading', error: undefined });
+    showToast(`正在生成 ${count} 条视频`);
+    const results: Array<{ url: string; mediaUrl: string; filePath?: string }> = [];
+    try {
+      for (let i = 0; i < count; i++) {
+        if (!isStill()) return;
+        const result = await generateVideo(params);
+        if (!isStill()) return;
+        const saved = submittingProjectId
+          ? await downloadUrlAndSave(result.url, submittingProjectId, 'ai-video', `${nodeLabel}-${i + 1}`).catch(() => null)
+          : null;
+        results.push({ url: result.url, mediaUrl: saved?.assetUrl || result.url, filePath: saved?.filePath });
+        recordOutputHistory(submittingNodeId, {
+          nodeId: submittingNodeId,
+          nodeLabel,
+          timestamp: Date.now(),
+          prompt: effectivePrompt,
+          output: result.url,
+          nodeType: 'ai-video',
+          model: nodeModel,
+          provider: nodeProvider,
+          status: 'success',
+          mediaUrl: result.url,
+          filePath: saved?.filePath,
+          params: { videoResolution: params.videoResolution, videoFps, videoFrames, seedanceResolution: params.seedanceResolution, seedanceRatio: params.seedanceRatio, seedanceDuration, generateAudio: params.generateAudio },
+        });
+      }
+      // 新建节点（垂直排开）+ 连线，一次历史快照
+      const nodeHeight = Number(sourceNode.data?.nodeHeight) || 220;
+      const gap = 40;
+      const newNodes = results.map((r, index) => {
+        const placement = derivedNodePlacement(sourceNode, 40);
+        return {
+          id: `node-${generateId()}`,
+          type: sourceNode.type,
+          position: {
+            x: placement.position.x,
+            y: placement.position.y + index * (nodeHeight + gap),
+          },
+          ...(placement.parentId ? { parentId: placement.parentId } : {}),
+          data: {
+            ...latestData,
+            label: `${nodeLabel}-${index + 1}`,
+            videoUrl: r.mediaUrl,
+            sourceUrl: r.url,
+            filePath: r.filePath,
+            thumbnailUrl: r.url,
+            output: r.url,
+            status: 'success',
+            generateInPlace: true,
+          } as BaseNodeData,
+        };
+      });
+      const newEdges = newNodes.map((n) => ({
+        id: `edge-${submittingNodeId}-${n.id}`,
+        source: submittingNodeId,
+        target: n.id,
+        sourceHandle: 'right',
+        targetHandle: 'left',
+      }));
+      addNodesWithEdges(newNodes, newEdges);
+      updateNodeDataTransient(submittingNodeId, { status: 'idle' });
+      showToast(`已生成 ${count} 条视频`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : (typeof err === 'string' && err.trim() ? err : '视频生成失败');
+      if (isStill()) updateNodeDataTransient(submittingNodeId, { status: 'idle', error: msg });
+      showToast(msg, 'error');
+    }
+  }, [activeNodeId, currentProjectId, showToast, updateNodeDataTransient, recordOutputHistory, addNodesWithEdges]);
+// 调用选中模型生成（文本 or 图片）
   // overridePrompt: / 指令菜单直接触发时传入的整合后模板，不走 store → 对话框不闪烁
-  const onSubmit = useCallback(async (overridePrompt?: string, postProcess?: ImagePostProcess) => {
-    finishContinuousEdit();
+  const onSubmit = useCallback(async (overridePrompt?: string, postProcess?: ImagePostProcess) => {    finishContinuousEdit();
     // 实时从 store 读取全部数据 — 避免闭包 data 为 undefined
     const store = useAppStore.getState();
     const latestNode = store.nodes.find((n) => n.id === activeNodeId);
@@ -496,9 +620,10 @@ function AINodeDialog() {
         });
         showToast('全景图生成完成');
       } else if (nodeType === 'ai-video') {
-        // 「在此节点生成」取消勾选 → 弹出数量选择（1-4 条），每条生成到右侧新建节点
+        // 「在此节点生成」取消勾选 → 按 generateCount 生成到右侧新建节点（不在此弹窗）
         if (latestData.generateInPlace === false) {
-          setPendingVideoCount(0);
+          const count = Math.min(4, Math.max(1, Math.floor(Number(latestData.generateCount) || 1)));
+          await runVideoToNewNodes(count);
           return;
         }
         const videoResolution = (latestData.videoResolution as number) || 832;
@@ -673,137 +798,9 @@ function AINodeDialog() {
       });
       showToast(msg, 'error');
     }
-  }, [activeNodeId, nodeType, currentProjectId, finishContinuousEdit, updateNodeData, updateNodeDataTransient, recordOutputHistory, showToast]);
+  }, [activeNodeId, nodeType, currentProjectId, finishContinuousEdit, updateNodeData, updateNodeDataTransient, recordOutputHistory, showToast, runVideoToNewNodes]);
 
-  /**
-   * 不勾选「在此节点生成」：串行生成 count 条视频，每条落到源节点右侧新建的视频节点并自动连线。
-   * 一次 addNodesWithEdges 提交全部节点与连线（单个历史快照）。
-   */
-  const runVideoToNewNodes = useCallback(async (count: number) => {
-    const store = useAppStore.getState();
-    const submittingNodeId = activeNodeId;
-    const submittingProjectId = currentProjectId;
-    if (!submittingNodeId || !submittingProjectId) return;
-    const sourceNode = store.nodes.find((n) => n.id === submittingNodeId);
-    if (!sourceNode) return;
-    const latestData = sourceNode.data as BaseNodeData;
-    const rawPrompt = latestData.prompt ?? '';
-    const nodeModel = latestData.model;
-    const nodeProvider = latestData.provider;
-    const nodeLabel = latestData.label ?? '视频';
-    if (!nodeModel || !nodeProvider) {
-      showToast('请先在底部模型选择器中选择一个模型', 'error');
-      return;
-    }
-    const projectSettings = store.projects.find((p) => p.id === submittingProjectId)?.settings;
-    const projectPrompt = resolveProjectGenerationPrompt({
-      prompt: rawPrompt,
-      data: latestData,
-      settings: projectSettings,
-      customStyles: store.customStyles,
-    });
-    const cameraPrompt = buildGenerationCameraPrompt(latestData.cameraSettings);
-    const effectivePrompt = cameraPrompt
-      ? `${projectPrompt}\n\nCamera settings: ${cameraPrompt}.`
-      : projectPrompt;
-    const videoFps = Number(latestData.videoFps) || 24;
-    const seedanceDuration = resolveVideoDurationSeconds(
-      latestData.seedanceDuration,
-      latestData.videoFrames,
-      videoFps,
-    );
-    const videoFrames = videoFramesFromDuration(seedanceDuration, videoFps);
-    const params = {
-      prompt: effectivePrompt,
-      model: nodeModel,
-      provider: nodeProvider,
-      videoResolution: Number(latestData.videoResolution) || 832,
-      videoFps,
-      videoFrames,
-      seedanceResolution: (latestData.seedanceResolution as string) || '720p',
-      seedanceRatio: (latestData.seedanceRatio as string) || '16:9',
-      seedanceDuration,
-      generateAudio: latestData.generateAudio,
-      workflowId: latestData.workflowId,
-      workflowInputs: latestData.workflowInputs,
-      nodeId: submittingNodeId,
-    };
-    const isStill = () => {
-      const s = useAppStore.getState();
-      return s.currentProjectId === submittingProjectId
-        && s.nodes.some((n) => n.id === submittingNodeId);
-    };
-    updateNodeDataTransient(submittingNodeId, { status: 'loading', error: undefined });
-    showToast(`正在生成 ${count} 条视频`);
-    const results: Array<{ url: string; mediaUrl: string; filePath?: string }> = [];
-    try {
-      for (let i = 0; i < count; i++) {
-        if (!isStill()) return;
-        const result = await generateVideo(params);
-        if (!isStill()) return;
-        const saved = submittingProjectId
-          ? await downloadUrlAndSave(result.url, submittingProjectId, 'ai-video', `${nodeLabel}-${i + 1}`).catch(() => null)
-          : null;
-        results.push({ url: result.url, mediaUrl: saved?.assetUrl || result.url, filePath: saved?.filePath });
-        recordOutputHistory(submittingNodeId, {
-          nodeId: submittingNodeId,
-          nodeLabel,
-          timestamp: Date.now(),
-          prompt: effectivePrompt,
-          output: result.url,
-          nodeType: 'ai-video',
-          model: nodeModel,
-          provider: nodeProvider,
-          status: 'success',
-          mediaUrl: result.url,
-          filePath: saved?.filePath,
-          params: { videoResolution: params.videoResolution, videoFps, videoFrames, seedanceResolution: params.seedanceResolution, seedanceRatio: params.seedanceRatio, seedanceDuration, generateAudio: params.generateAudio },
-        });
-      }
-      // 新建节点（垂直排开）+ 连线，一次历史快照
-      const nodeHeight = Number(sourceNode.data?.nodeHeight) || 220;
-      const gap = 40;
-      const newNodes = results.map((r, index) => {
-        const placement = derivedNodePlacement(sourceNode, 40);
-        return {
-          id: `node-${generateId()}`,
-          type: sourceNode.type,
-          position: {
-            x: placement.position.x,
-            y: placement.position.y + index * (nodeHeight + gap),
-          },
-          ...(placement.parentId ? { parentId: placement.parentId } : {}),
-          data: {
-            ...latestData,
-            label: `${nodeLabel}-${index + 1}`,
-            videoUrl: r.mediaUrl,
-            sourceUrl: r.url,
-            filePath: r.filePath,
-            thumbnailUrl: r.url,
-            output: r.url,
-            status: 'success',
-            generateInPlace: true,
-          } as BaseNodeData,
-        };
-      });
-      const newEdges = newNodes.map((n) => ({
-        id: `edge-${submittingNodeId}-${n.id}`,
-        source: submittingNodeId,
-        target: n.id,
-        sourceHandle: 'right',
-        targetHandle: 'left',
-      }));
-      addNodesWithEdges(newNodes, newEdges);
-      updateNodeDataTransient(submittingNodeId, { status: 'idle' });
-      showToast(`已生成 ${count} 条视频`);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : (typeof err === 'string' && err.trim() ? err : '视频生成失败');
-      if (isStill()) updateNodeDataTransient(submittingNodeId, { status: 'idle', error: msg });
-      showToast(msg, 'error');
-    } finally {
-      setPendingVideoCount(null);
-    }
-  }, [activeNodeId, currentProjectId, showToast, updateNodeDataTransient, recordOutputHistory, addNodesWithEdges]);
+
 
   const onCancelGeneration = useCallback(async () => {
     if (!activeNodeId || cancellingNodeIdsRef.current.has(activeNodeId)) return;
@@ -1001,40 +998,6 @@ function AINodeDialog() {
 
   return (
     <>
-      {/* 不勾选「在此节点生成」时的数量选择浮层 */}
-      {pendingVideoCount !== null && (
-        <div
-          className="fixed inset-0 z-[100] flex items-center justify-center bg-black/40"
-          onClick={() => setPendingVideoCount(null)}
-        >
-          <div
-            className="rounded-lg border border-canvas-border bg-canvas-card p-4 space-y-3 shadow-xl"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div className="text-sm font-medium text-canvas-text">生成几条视频？</div>
-            <div className="flex items-center gap-2">
-              {[1, 2, 3, 4].map((n) => (
-                <button
-                  key={n}
-                  type="button"
-                  className="settings-save-btn min-w-[52px] justify-center text-sm"
-                  onClick={() => void runVideoToNewNodes(n)}
-                >
-                  {n} 条
-                </button>
-              ))}
-            </div>
-            <button
-              type="button"
-              className="settings-save-btn settings-btn-ghost w-full"
-              onClick={() => setPendingVideoCount(null)}
-            >
-              取消
-            </button>
-          </div>
-        </div>
-      )}
-
       {/* Connected nodes preview — below dialog (model-dropdown covers it) */}
       <div
         ref={previewRef}

--- a/src/components/nodes/AINodeDialog.tsx
+++ b/src/components/nodes/AINodeDialog.tsx
@@ -288,9 +288,10 @@ function AINodeDialog() {
     [updateContinuousNodeData]
   );
 
-    /**
-   * 不勾选「在此节点生成」：串行生成 count 条视频，每条落到源节点右侧新建的视频节点并自动连线。
-   * 一次 addNodesWithEdges 提交全部节点与连线（单个历史快照）。
+  /**
+   * 不勾选「在此节点生成」：立即构建 count 个空白视频节点（占位，显示生成中），
+   * 并行向模型提交 count 个生成请求，各自完成后把结果填入对应空白节点。
+   * 节点与连线一次 addNodesWithEdges 提交（单个历史快照）。
    */
   const runVideoToNewNodes = useCallback(async (count: number) => {
     const store = useAppStore.getState();
@@ -326,7 +327,7 @@ function AINodeDialog() {
       videoFps,
     );
     const videoFrames = videoFramesFromDuration(seedanceDuration, videoFps);
-    const params = {
+    const baseParams = {
       prompt: effectivePrompt,
       model: nodeModel,
       provider: nodeProvider,
@@ -339,28 +340,73 @@ function AINodeDialog() {
       generateAudio: latestData.generateAudio,
       workflowId: latestData.workflowId,
       workflowInputs: latestData.workflowInputs,
-      nodeId: submittingNodeId,
     };
     const isStill = () => {
       const s = useAppStore.getState();
       return s.currentProjectId === submittingProjectId
         && s.nodes.some((n) => n.id === submittingNodeId);
     };
-    updateNodeDataTransient(submittingNodeId, { status: 'loading', error: undefined });
-    showToast(`正在生成 ${count} 条视频`);
-    const results: Array<{ url: string; mediaUrl: string; filePath?: string }> = [];
-    try {
-      for (let i = 0; i < count; i++) {
+
+    // 1. 立即构建 count 个空白节点（status='loading' 占位）+ 连线，一次历史快照
+    const nodeHeight = Number(sourceNode.data?.nodeHeight) || 220;
+    const gap = 40;
+    const newNodes = Array.from({ length: count }, (_, index) => {
+      const placement = derivedNodePlacement(sourceNode, 40);
+      return {
+        id: `node-${generateId()}`,
+        type: sourceNode.type,
+        position: {
+          x: placement.position.x,
+          y: placement.position.y + index * (nodeHeight + gap),
+        },
+        ...(placement.parentId ? { parentId: placement.parentId } : {}),
+        data: {
+          ...latestData,
+          label: `${nodeLabel}-${index + 1}`,
+          videoUrl: undefined,
+          sourceUrl: undefined,
+          filePath: undefined,
+          thumbnailUrl: undefined,
+          output: undefined,
+          status: 'loading',
+          error: undefined,
+          generateInPlace: true,
+        } as BaseNodeData,
+      };
+    });
+    const newEdges = newNodes.map((n) => ({
+      id: `edge-${submittingNodeId}-${n.id}`,
+      source: submittingNodeId,
+      target: n.id,
+      sourceHandle: 'right',
+      targetHandle: 'left',
+    }));
+    addNodesWithEdges(newNodes, newEdges);
+    showToast(`正在并行生成 ${count} 条视频`);
+
+    // 2. 并行提交生成请求，每个结果填入对应空白节点
+    await Promise.all(newNodes.map(async (node, index) => {
+      const nodeParams = { ...baseParams, nodeId: node.id };
+      try {
         if (!isStill()) return;
-        const result = await generateVideo(params);
+        const result = await generateVideo(nodeParams);
         if (!isStill()) return;
         const saved = submittingProjectId
-          ? await downloadUrlAndSave(result.url, submittingProjectId, 'ai-video', `${nodeLabel}-${i + 1}`).catch(() => null)
+          ? await downloadUrlAndSave(result.url, submittingProjectId, 'ai-video', `${nodeLabel}-${index + 1}`).catch(() => null)
           : null;
-        results.push({ url: result.url, mediaUrl: saved?.assetUrl || result.url, filePath: saved?.filePath });
-        recordOutputHistory(submittingNodeId, {
-          nodeId: submittingNodeId,
-          nodeLabel,
+        const mediaUrl = saved?.assetUrl || result.url;
+        useAppStore.getState().updateNodeData(node.id, {
+          videoUrl: mediaUrl,
+          sourceUrl: result.url,
+          filePath: saved?.filePath,
+          thumbnailUrl: result.url,
+          output: result.url,
+          status: 'success',
+          error: undefined,
+        });
+        recordOutputHistory(node.id, {
+          nodeId: node.id,
+          nodeLabel: `${nodeLabel}-${index + 1}`,
           timestamp: Date.now(),
           prompt: effectivePrompt,
           output: result.url,
@@ -370,54 +416,21 @@ function AINodeDialog() {
           status: 'success',
           mediaUrl: result.url,
           filePath: saved?.filePath,
-          params: { videoResolution: params.videoResolution, videoFps, videoFrames, seedanceResolution: params.seedanceResolution, seedanceRatio: params.seedanceRatio, seedanceDuration, generateAudio: params.generateAudio },
+          params: { videoResolution: baseParams.videoResolution, videoFps, videoFrames, seedanceResolution: baseParams.seedanceResolution, seedanceRatio: baseParams.seedanceRatio, seedanceDuration, generateAudio: baseParams.generateAudio },
         });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : (typeof err === 'string' && err.trim() ? err : '视频生成失败');
+        if (isStill()) useAppStore.getState().updateNodeData(node.id, { status: 'error', error: msg });
       }
-      // 新建节点（垂直排开）+ 连线，一次历史快照
-      const nodeHeight = Number(sourceNode.data?.nodeHeight) || 220;
-      const gap = 40;
-      const newNodes = results.map((r, index) => {
-        const placement = derivedNodePlacement(sourceNode, 40);
-        return {
-          id: `node-${generateId()}`,
-          type: sourceNode.type,
-          position: {
-            x: placement.position.x,
-            y: placement.position.y + index * (nodeHeight + gap),
-          },
-          ...(placement.parentId ? { parentId: placement.parentId } : {}),
-          data: {
-            ...latestData,
-            label: `${nodeLabel}-${index + 1}`,
-            videoUrl: r.mediaUrl,
-            sourceUrl: r.url,
-            filePath: r.filePath,
-            thumbnailUrl: r.url,
-            output: r.url,
-            status: 'success',
-            generateInPlace: true,
-          } as BaseNodeData,
-        };
-      });
-      const newEdges = newNodes.map((n) => ({
-        id: `edge-${submittingNodeId}-${n.id}`,
-        source: submittingNodeId,
-        target: n.id,
-        sourceHandle: 'right',
-        targetHandle: 'left',
-      }));
-      addNodesWithEdges(newNodes, newEdges);
-      updateNodeDataTransient(submittingNodeId, { status: 'idle' });
-      showToast(`已生成 ${count} 条视频`);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : (typeof err === 'string' && err.trim() ? err : '视频生成失败');
-      if (isStill()) updateNodeDataTransient(submittingNodeId, { status: 'idle', error: msg });
-      showToast(msg, 'error');
-    }
+    }));
+
+    if (isStill()) updateNodeDataTransient(submittingNodeId, { status: 'idle' });
   }, [activeNodeId, currentProjectId, showToast, updateNodeDataTransient, recordOutputHistory, addNodesWithEdges]);
-// 调用选中模型生成（文本 or 图片）
+
+  // 调用选中模型生成（文本 or 图片）
   // overridePrompt: / 指令菜单直接触发时传入的整合后模板，不走 store → 对话框不闪烁
-  const onSubmit = useCallback(async (overridePrompt?: string, postProcess?: ImagePostProcess) => {    finishContinuousEdit();
+  const onSubmit = useCallback(async (overridePrompt?: string, postProcess?: ImagePostProcess) => {
+    finishContinuousEdit();
     // 实时从 store 读取全部数据 — 避免闭包 data 为 undefined
     const store = useAppStore.getState();
     const latestNode = store.nodes.find((n) => n.id === activeNodeId);

--- a/src/components/nodes/AINodeDialog.tsx
+++ b/src/components/nodes/AINodeDialog.tsx
@@ -235,6 +235,21 @@ function AINodeDialog() {
     }
     updateNodeDataTransient(activeNodeId, patch);
   }, [activeNodeId, commitToHistory, updateNodeDataTransient]);
+
+  // 视频节点「在此节点生成」与数量：与时长滑块同一套连续写入（transient，拖动不卡）
+  const generateInPlace = data?.generateInPlace !== false;
+  const generateCount = (() => {
+    const raw = Number(data?.generateCount);
+    return Number.isFinite(raw) && raw >= 1 && raw <= 4 ? Math.floor(raw) : 1;
+  })();
+  const onChangeGenerateInPlace = useCallback(
+    (value: boolean) => updateContinuousNodeData({ generateInPlace: value }),
+    [updateContinuousNodeData],
+  );
+  const onChangeGenerateCount = useCallback(
+    (value: number) => updateContinuousNodeData({ generateCount: Math.min(4, Math.max(1, Math.floor(value))) }),
+    [updateContinuousNodeData],
+  );
   const handleCloseNodeDialog = useCallback(() => {
     finishContinuousEdit();
     closeNodeDialog();
@@ -1060,6 +1075,10 @@ function AINodeDialog() {
           seedanceRatio={(data.seedanceRatio as string) || '16:9'}
           seedanceDuration={data.seedanceDuration as number | undefined}
           generateAudio={data.generateAudio as boolean | undefined}
+          generateInPlace={generateInPlace}
+          generateCount={generateCount}
+          onChangeGenerateInPlace={onChangeGenerateInPlace}
+          onChangeGenerateCount={onChangeGenerateCount}
           videoReferences={data.videoReferences}
           onChangeVideoReferences={onChangeVideoReferences}
           onChangeSeedanceResolution={onChangeSeedanceResolution}

--- a/src/components/nodes/AINodeDialog.tsx
+++ b/src/components/nodes/AINodeDialog.tsx
@@ -1,7 +1,7 @@
 /**
  * AINodeDialog AI 生成弹窗 — 点击节点后弹出的浮动面板，包含 Prompt 输入、模型选择、参数配置、生成按钮
  */
-import { memo, useCallback, useEffect, useLayoutEffect, useRef } from 'react';
+import { memo, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { convertFileSrc } from '@tauri-apps/api/core';
 import { useShallow } from 'zustand/react/shallow';
 import { generateId, useAppStore } from '../../store/useAppStore';
@@ -40,7 +40,7 @@ import { cancelComfyUINodeTask } from '../../services/comfyWorkflowService';
 const DIALOG_VIEWPORT_MARGIN = 16;
 
 function AINodeDialog() {
-  const { activeNodeId, dialogPosition, closeNodeDialog, updateNodeData, updateNodeDataTransient, commitToHistory, recordOutputHistory, showToast, workflows, currentProjectId } = useAppStore(
+  const { activeNodeId, dialogPosition, closeNodeDialog, updateNodeData, updateNodeDataTransient, commitToHistory, recordOutputHistory, showToast, workflows, currentProjectId, addNodesWithEdges } = useAppStore(
     useShallow((s) => ({
       activeNodeId: s.activeNodeId,
       dialogPosition: s.dialogPosition,
@@ -52,6 +52,7 @@ function AINodeDialog() {
       showToast: s.showToast,
       workflows: s.workflows,
       currentProjectId: s.currentProjectId,
+      addNodesWithEdges: s.addNodesWithEdges,
     })),
   );
 
@@ -63,6 +64,8 @@ function AINodeDialog() {
   const panelRef = useRef<HTMLDivElement>(null);
   const previewRef = useRef<HTMLDivElement>(null);
   const cancellingNodeIdsRef = useRef(new Set<string>());
+  // 不勾选「在此节点生成」时，待选的新节点数量（null=不显示选择框；1-4 选中后执行）
+  const [pendingVideoCount, setPendingVideoCount] = useState<number | null>(null);
 
   useLayoutEffect(() => {
     const panel = panelRef.current;
@@ -493,6 +496,11 @@ function AINodeDialog() {
         });
         showToast('全景图生成完成');
       } else if (nodeType === 'ai-video') {
+        // 「在此节点生成」取消勾选 → 弹出数量选择（1-4 条），每条生成到右侧新建节点
+        if (latestData.generateInPlace === false) {
+          setPendingVideoCount(0);
+          return;
+        }
         const videoResolution = (latestData.videoResolution as number) || 832;
         const videoFps = (latestData.videoFps as number) || 24;
         const seedanceDuration = resolveVideoDurationSeconds(
@@ -666,6 +674,136 @@ function AINodeDialog() {
       showToast(msg, 'error');
     }
   }, [activeNodeId, nodeType, currentProjectId, finishContinuousEdit, updateNodeData, updateNodeDataTransient, recordOutputHistory, showToast]);
+
+  /**
+   * 不勾选「在此节点生成」：串行生成 count 条视频，每条落到源节点右侧新建的视频节点并自动连线。
+   * 一次 addNodesWithEdges 提交全部节点与连线（单个历史快照）。
+   */
+  const runVideoToNewNodes = useCallback(async (count: number) => {
+    const store = useAppStore.getState();
+    const submittingNodeId = activeNodeId;
+    const submittingProjectId = currentProjectId;
+    if (!submittingNodeId || !submittingProjectId) return;
+    const sourceNode = store.nodes.find((n) => n.id === submittingNodeId);
+    if (!sourceNode) return;
+    const latestData = sourceNode.data as BaseNodeData;
+    const rawPrompt = latestData.prompt ?? '';
+    const nodeModel = latestData.model;
+    const nodeProvider = latestData.provider;
+    const nodeLabel = latestData.label ?? '视频';
+    if (!nodeModel || !nodeProvider) {
+      showToast('请先在底部模型选择器中选择一个模型', 'error');
+      return;
+    }
+    const projectSettings = store.projects.find((p) => p.id === submittingProjectId)?.settings;
+    const projectPrompt = resolveProjectGenerationPrompt({
+      prompt: rawPrompt,
+      data: latestData,
+      settings: projectSettings,
+      customStyles: store.customStyles,
+    });
+    const cameraPrompt = buildGenerationCameraPrompt(latestData.cameraSettings);
+    const effectivePrompt = cameraPrompt
+      ? `${projectPrompt}\n\nCamera settings: ${cameraPrompt}.`
+      : projectPrompt;
+    const videoFps = Number(latestData.videoFps) || 24;
+    const seedanceDuration = resolveVideoDurationSeconds(
+      latestData.seedanceDuration,
+      latestData.videoFrames,
+      videoFps,
+    );
+    const videoFrames = videoFramesFromDuration(seedanceDuration, videoFps);
+    const params = {
+      prompt: effectivePrompt,
+      model: nodeModel,
+      provider: nodeProvider,
+      videoResolution: Number(latestData.videoResolution) || 832,
+      videoFps,
+      videoFrames,
+      seedanceResolution: (latestData.seedanceResolution as string) || '720p',
+      seedanceRatio: (latestData.seedanceRatio as string) || '16:9',
+      seedanceDuration,
+      generateAudio: latestData.generateAudio,
+      workflowId: latestData.workflowId,
+      workflowInputs: latestData.workflowInputs,
+      nodeId: submittingNodeId,
+    };
+    const isStill = () => {
+      const s = useAppStore.getState();
+      return s.currentProjectId === submittingProjectId
+        && s.nodes.some((n) => n.id === submittingNodeId);
+    };
+    updateNodeDataTransient(submittingNodeId, { status: 'loading', error: undefined });
+    showToast(`正在生成 ${count} 条视频`);
+    const results: Array<{ url: string; mediaUrl: string; filePath?: string }> = [];
+    try {
+      for (let i = 0; i < count; i++) {
+        if (!isStill()) return;
+        const result = await generateVideo(params);
+        if (!isStill()) return;
+        const saved = submittingProjectId
+          ? await downloadUrlAndSave(result.url, submittingProjectId, 'ai-video', `${nodeLabel}-${i + 1}`).catch(() => null)
+          : null;
+        results.push({ url: result.url, mediaUrl: saved?.assetUrl || result.url, filePath: saved?.filePath });
+        recordOutputHistory(submittingNodeId, {
+          nodeId: submittingNodeId,
+          nodeLabel,
+          timestamp: Date.now(),
+          prompt: effectivePrompt,
+          output: result.url,
+          nodeType: 'ai-video',
+          model: nodeModel,
+          provider: nodeProvider,
+          status: 'success',
+          mediaUrl: result.url,
+          filePath: saved?.filePath,
+          params: { videoResolution: params.videoResolution, videoFps, videoFrames, seedanceResolution: params.seedanceResolution, seedanceRatio: params.seedanceRatio, seedanceDuration, generateAudio: params.generateAudio },
+        });
+      }
+      // 新建节点（垂直排开）+ 连线，一次历史快照
+      const nodeHeight = Number(sourceNode.data?.nodeHeight) || 220;
+      const gap = 40;
+      const newNodes = results.map((r, index) => {
+        const placement = derivedNodePlacement(sourceNode, 40);
+        return {
+          id: `node-${generateId()}`,
+          type: sourceNode.type,
+          position: {
+            x: placement.position.x,
+            y: placement.position.y + index * (nodeHeight + gap),
+          },
+          ...(placement.parentId ? { parentId: placement.parentId } : {}),
+          data: {
+            ...latestData,
+            label: `${nodeLabel}-${index + 1}`,
+            videoUrl: r.mediaUrl,
+            sourceUrl: r.url,
+            filePath: r.filePath,
+            thumbnailUrl: r.url,
+            output: r.url,
+            status: 'success',
+            generateInPlace: true,
+          } as BaseNodeData,
+        };
+      });
+      const newEdges = newNodes.map((n) => ({
+        id: `edge-${submittingNodeId}-${n.id}`,
+        source: submittingNodeId,
+        target: n.id,
+        sourceHandle: 'right',
+        targetHandle: 'left',
+      }));
+      addNodesWithEdges(newNodes, newEdges);
+      updateNodeDataTransient(submittingNodeId, { status: 'idle' });
+      showToast(`已生成 ${count} 条视频`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : (typeof err === 'string' && err.trim() ? err : '视频生成失败');
+      if (isStill()) updateNodeDataTransient(submittingNodeId, { status: 'idle', error: msg });
+      showToast(msg, 'error');
+    } finally {
+      setPendingVideoCount(null);
+    }
+  }, [activeNodeId, currentProjectId, showToast, updateNodeDataTransient, recordOutputHistory, addNodesWithEdges]);
 
   const onCancelGeneration = useCallback(async () => {
     if (!activeNodeId || cancellingNodeIdsRef.current.has(activeNodeId)) return;
@@ -863,6 +1001,40 @@ function AINodeDialog() {
 
   return (
     <>
+      {/* 不勾选「在此节点生成」时的数量选择浮层 */}
+      {pendingVideoCount !== null && (
+        <div
+          className="fixed inset-0 z-[100] flex items-center justify-center bg-black/40"
+          onClick={() => setPendingVideoCount(null)}
+        >
+          <div
+            className="rounded-lg border border-canvas-border bg-canvas-card p-4 space-y-3 shadow-xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="text-sm font-medium text-canvas-text">生成几条视频？</div>
+            <div className="flex items-center gap-2">
+              {[1, 2, 3, 4].map((n) => (
+                <button
+                  key={n}
+                  type="button"
+                  className="settings-save-btn min-w-[52px] justify-center text-sm"
+                  onClick={() => void runVideoToNewNodes(n)}
+                >
+                  {n} 条
+                </button>
+              ))}
+            </div>
+            <button
+              type="button"
+              className="settings-save-btn settings-btn-ghost w-full"
+              onClick={() => setPendingVideoCount(null)}
+            >
+              取消
+            </button>
+          </div>
+        </div>
+      )}
+
       {/* Connected nodes preview — below dialog (model-dropdown covers it) */}
       <div
         ref={previewRef}

--- a/src/components/nodes/shared/PromptPanel.tsx
+++ b/src/components/nodes/shared/PromptPanel.tsx
@@ -451,6 +451,16 @@ export default function PromptPanel({
   const pendingPresetAction = useAppStore((s) => s.pendingPresetAction);
   const setPendingPresetAction = useAppStore((s) => s.setPendingPresetAction);
 
+  // 视频节点：是否在当前节点生成（默认 true，老节点按原逻辑）
+  const generateInPlace = useAppStore((s) => {
+    const node = s.nodes.find((n) => n.id === nodeId);
+    return (node?.data as import('../../../types').BaseNodeData | undefined)?.generateInPlace !== false;
+  });
+  const updateNodeData = useAppStore((s) => s.updateNodeData);
+  const onChangeGenerateInPlace = useCallback((value: boolean) => {
+    if (nodeId) updateNodeData(nodeId, { generateInPlace: value });
+  }, [nodeId, updateNodeData]);
+
   const handleSubmit = useCallback((overridePrompt?: string, postProcess?: ImagePostProcess) => {
     const sourcePrompt = overridePrompt ?? prompt;
     onSubmit(expandSkillReferences(sourcePrompt, userSkills), postProcess);
@@ -722,6 +732,8 @@ export default function PromptPanel({
             seedanceRatio={seedanceRatio}
             seedanceDuration={seedanceDuration}
             generateAudio={generateAudio}
+            generateInPlace={generateInPlace}
+            onChangeGenerateInPlace={onChangeGenerateInPlace}
             onChangeSeedanceResolution={onChangeSeedanceResolution}
             onChangeSeedanceRatio={onChangeSeedanceRatio}
             onChangeSeedanceDuration={onChangeSeedanceDuration}

--- a/src/components/nodes/shared/PromptPanel.tsx
+++ b/src/components/nodes/shared/PromptPanel.tsx
@@ -335,6 +335,12 @@ interface PromptPanelProps {
   seedanceRatio?: string;
   seedanceDuration?: number;
   generateAudio?: boolean;
+  /** 视频节点：在此节点生成并替换旧视频；false 时生成到右侧新建节点。默认 true。 */
+  generateInPlace?: boolean;
+  onChangeGenerateInPlace?: (value: boolean) => void;
+  /** 不在此节点生成时的数量（1-4），默认 1。 */
+  generateCount?: number;
+  onChangeGenerateCount?: (value: number) => void;
   videoReferences?: VideoReferenceItem[];
   onChangeVideoReferences?: (value: VideoReferenceItem[]) => void;
   onChangeSeedanceResolution?: (value: string) => void;
@@ -403,6 +409,10 @@ export default function PromptPanel({
   seedanceRatio,
   seedanceDuration,
   generateAudio,
+  generateInPlace,
+  onChangeGenerateInPlace,
+  generateCount,
+  onChangeGenerateCount,
   videoReferences,
   onChangeVideoReferences,
   onChangeSeedanceResolution,
@@ -450,25 +460,6 @@ export default function PromptPanel({
   const showToast = useAppStore((s) => s.showToast);
   const pendingPresetAction = useAppStore((s) => s.pendingPresetAction);
   const setPendingPresetAction = useAppStore((s) => s.setPendingPresetAction);
-
-  // 视频节点：是否在当前节点生成（默认 true，老节点按原逻辑）
-  const generateInPlace = useAppStore((s) => {
-    const node = s.nodes.find((n) => n.id === nodeId);
-    return (node?.data as import('../../../types').BaseNodeData | undefined)?.generateInPlace !== false;
-  });
-  const generateCount = useAppStore((s) => {
-    const node = s.nodes.find((n) => n.id === nodeId);
-    const raw = (node?.data as import('../../../types').BaseNodeData | undefined)?.generateCount;
-    const parsed = Number(raw);
-    return Number.isFinite(parsed) && parsed >= 1 && parsed <= 4 ? Math.floor(parsed) : 1;
-  });
-  const updateNodeData = useAppStore((s) => s.updateNodeData);
-  const onChangeGenerateInPlace = useCallback((value: boolean) => {
-    if (nodeId) updateNodeData(nodeId, { generateInPlace: value });
-  }, [nodeId, updateNodeData]);
-  const onChangeGenerateCount = useCallback((value: number) => {
-    if (nodeId) updateNodeData(nodeId, { generateCount: Math.min(4, Math.max(1, Math.floor(value))) });
-  }, [nodeId, updateNodeData]);
 
   const handleSubmit = useCallback((overridePrompt?: string, postProcess?: ImagePostProcess) => {
     const sourcePrompt = overridePrompt ?? prompt;

--- a/src/components/nodes/shared/PromptPanel.tsx
+++ b/src/components/nodes/shared/PromptPanel.tsx
@@ -456,9 +456,18 @@ export default function PromptPanel({
     const node = s.nodes.find((n) => n.id === nodeId);
     return (node?.data as import('../../../types').BaseNodeData | undefined)?.generateInPlace !== false;
   });
+  const generateCount = useAppStore((s) => {
+    const node = s.nodes.find((n) => n.id === nodeId);
+    const raw = (node?.data as import('../../../types').BaseNodeData | undefined)?.generateCount;
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) && parsed >= 1 && parsed <= 4 ? Math.floor(parsed) : 1;
+  });
   const updateNodeData = useAppStore((s) => s.updateNodeData);
   const onChangeGenerateInPlace = useCallback((value: boolean) => {
     if (nodeId) updateNodeData(nodeId, { generateInPlace: value });
+  }, [nodeId, updateNodeData]);
+  const onChangeGenerateCount = useCallback((value: number) => {
+    if (nodeId) updateNodeData(nodeId, { generateCount: Math.min(4, Math.max(1, Math.floor(value))) });
   }, [nodeId, updateNodeData]);
 
   const handleSubmit = useCallback((overridePrompt?: string, postProcess?: ImagePostProcess) => {
@@ -733,7 +742,9 @@ export default function PromptPanel({
             seedanceDuration={seedanceDuration}
             generateAudio={generateAudio}
             generateInPlace={generateInPlace}
+            generateCount={generateCount}
             onChangeGenerateInPlace={onChangeGenerateInPlace}
+            onChangeGenerateCount={onChangeGenerateCount}
             onChangeSeedanceResolution={onChangeSeedanceResolution}
             onChangeSeedanceRatio={onChangeSeedanceRatio}
             onChangeSeedanceDuration={onChangeSeedanceDuration}

--- a/src/components/nodes/shared/VideoParamSelector.tsx
+++ b/src/components/nodes/shared/VideoParamSelector.tsx
@@ -38,6 +38,9 @@ interface VideoParamSelectorProps {
   seedanceRatio?: string;
   seedanceDuration?: number;
   generateAudio?: boolean;
+  /** 视频节点：在此节点生成并替换旧视频；false 时生成到右侧新建节点。默认 true。 */
+  generateInPlace?: boolean;
+  onChangeGenerateInPlace?: (value: boolean) => void;
   onChangeSeedanceResolution?: (value: string) => void;
   onChangeSeedanceRatio?: (value: string) => void;
   onChangeSeedanceDuration?: (value: number) => void;
@@ -86,9 +89,9 @@ export default function VideoParamSelector({
   videoResolution = 832, videoFps = 24, videoFrames = 77,
   onChangeResolution, onChangeFps,
   seedanceResolution = '720p', seedanceRatio = '16:9',
-  seedanceDuration, generateAudio,
+  seedanceDuration, generateAudio, generateInPlace = true,
   onChangeSeedanceResolution, onChangeSeedanceRatio,
-  onChangeSeedanceDuration, onChangeGenerateAudio,
+  onChangeSeedanceDuration, onChangeGenerateAudio, onChangeGenerateInPlace,
   showSeedanceRatio = true, showGenerateAudio = true, onContinuousEditEnd,
 }: VideoParamSelectorProps) {
   const [open, setOpen] = useState(false);
@@ -533,6 +536,26 @@ export default function VideoParamSelector({
                     </div>
                   </div>
                   )}
+
+                  {/* 在此节点生成 — 勾选=替换本节点旧视频；不勾选=生成到右侧新建节点 */}
+                  <div className="rh-vram-adv-row">
+                    <div className="rh-vram-adv-label" style={{ justifyContent: 'space-between', width: '100%' }}>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                        <span>在此节点生成</span>
+                        <span className="rh-tip" data-tooltip="勾选时生成结果直接替换本节点旧视频；取消勾选后，点生成会询问数量（1-4 条），每条生成到本节点右侧新建的视频节点并自动连线。">!</span>
+                      </div>
+                      <label className="rh-toggle-switch">
+                        <input
+                          type="checkbox"
+                          checked={generateInPlace}
+                          onChange={(e) => onChangeGenerateInPlace?.(e.target.checked)}
+                        />
+                        <span className="rh-toggle-track">
+                          <span className="rh-toggle-knob" />
+                        </span>
+                      </label>
+                    </div>
+                  </div>
                 </div>
                 )}
               </>

--- a/src/components/nodes/shared/VideoParamSelector.tsx
+++ b/src/components/nodes/shared/VideoParamSelector.tsx
@@ -41,6 +41,9 @@ interface VideoParamSelectorProps {
   /** 视频节点：在此节点生成并替换旧视频；false 时生成到右侧新建节点。默认 true。 */
   generateInPlace?: boolean;
   onChangeGenerateInPlace?: (value: boolean) => void;
+  /** 不在此节点生成时的数量（1-4），默认 1。 */
+  generateCount?: number;
+  onChangeGenerateCount?: (value: number) => void;
   onChangeSeedanceResolution?: (value: string) => void;
   onChangeSeedanceRatio?: (value: string) => void;
   onChangeSeedanceDuration?: (value: number) => void;
@@ -89,9 +92,9 @@ export default function VideoParamSelector({
   videoResolution = 832, videoFps = 24, videoFrames = 77,
   onChangeResolution, onChangeFps,
   seedanceResolution = '720p', seedanceRatio = '16:9',
-  seedanceDuration, generateAudio, generateInPlace = true,
+  seedanceDuration, generateAudio, generateInPlace = true, generateCount = 1,
   onChangeSeedanceResolution, onChangeSeedanceRatio,
-  onChangeSeedanceDuration, onChangeGenerateAudio, onChangeGenerateInPlace,
+  onChangeSeedanceDuration, onChangeGenerateAudio, onChangeGenerateInPlace, onChangeGenerateCount,
   showSeedanceRatio = true, showGenerateAudio = true, onContinuousEditEnd,
 }: VideoParamSelectorProps) {
   const [open, setOpen] = useState(false);
@@ -682,7 +685,7 @@ export default function VideoParamSelector({
               <div className="rh-vram-adv-label" style={{ justifyContent: 'space-between', width: '100%' }}>
                 <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
                   <span>在此节点生成</span>
-                  <span className="rh-tip" data-tooltip="勾选时生成结果直接替换本节点旧视频；取消勾选后，点生成会询问数量（1-4 条），每条生成到本节点右侧新建的视频节点并自动连线。">!</span>
+                  <span className="rh-tip" data-tooltip="勾选时生成结果直接替换本节点旧视频；取消勾选后，点生成会按下方数量（1-4 条）生成到本节点右侧新建的视频节点并自动连线。">!</span>
                 </div>
                 <label className="rh-toggle-switch">
                   <input
@@ -696,6 +699,45 @@ export default function VideoParamSelector({
                 </label>
               </div>
             </div>
+
+            {/* 不在此节点生成时的数量滑块（1-4 条）— 与时长滑块同款 */}
+            {!generateInPlace && (
+              <div className="img-rp-quality-area mb-1">
+                <div className="img-rp-section-label">
+                  生成数量
+                  <span className="rh-tip" data-tooltip="取消「在此节点生成」后，本次生成会在本节点右侧新建 N 个视频节点，每条一条结果并自动连线。">!</span>
+                </div>
+                <div className="rh-duration-slider">
+                  <div className="rh-duration-track">
+                    <div
+                      className="rh-duration-fill"
+                      style={{ width: `${((generateCount - 1) / (4 - 1)) * 100}%` }}
+                    />
+                    <input
+                      type="range"
+                      className="rh-duration-input"
+                      min={1}
+                      max={4}
+                      step={1}
+                      value={generateCount}
+                      onChange={(e) => onChangeGenerateCount?.(Number(e.target.value))}
+                      onBlur={onContinuousEditEnd}
+                    />
+                  </div>
+                  <div className="rh-duration-labels">
+                    {[1, 2, 3, 4].map((value) => (
+                      <span
+                        key={value}
+                        className={`rh-duration-tick ${generateCount >= value ? 'active' : ''}`}
+                        onClick={() => onChangeGenerateCount?.(value)}
+                      >
+                        {`${value}条`}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/src/components/nodes/shared/VideoParamSelector.tsx
+++ b/src/components/nodes/shared/VideoParamSelector.tsx
@@ -536,26 +536,6 @@ export default function VideoParamSelector({
                     </div>
                   </div>
                   )}
-
-                  {/* 在此节点生成 — 勾选=替换本节点旧视频；不勾选=生成到右侧新建节点 */}
-                  <div className="rh-vram-adv-row">
-                    <div className="rh-vram-adv-label" style={{ justifyContent: 'space-between', width: '100%' }}>
-                      <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-                        <span>在此节点生成</span>
-                        <span className="rh-tip" data-tooltip="勾选时生成结果直接替换本节点旧视频；取消勾选后，点生成会询问数量（1-4 条），每条生成到本节点右侧新建的视频节点并自动连线。">!</span>
-                      </div>
-                      <label className="rh-toggle-switch">
-                        <input
-                          type="checkbox"
-                          checked={generateInPlace}
-                          onChange={(e) => onChangeGenerateInPlace?.(e.target.checked)}
-                        />
-                        <span className="rh-toggle-track">
-                          <span className="rh-toggle-knob" />
-                        </span>
-                      </label>
-                    </div>
-                  </div>
                 </div>
                 )}
               </>
@@ -696,6 +676,26 @@ export default function VideoParamSelector({
                 </div>
               </>
             )}
+
+            {/* 在此节点生成 — 所有视频模型通用：勾选=替换本节点旧视频；不勾选=生成到右侧新建节点 */}
+            <div className="rh-vram-adv-row">
+              <div className="rh-vram-adv-label" style={{ justifyContent: 'space-between', width: '100%' }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                  <span>在此节点生成</span>
+                  <span className="rh-tip" data-tooltip="勾选时生成结果直接替换本节点旧视频；取消勾选后，点生成会询问数量（1-4 条），每条生成到本节点右侧新建的视频节点并自动连线。">!</span>
+                </div>
+                <label className="rh-toggle-switch">
+                  <input
+                    type="checkbox"
+                    checked={generateInPlace}
+                    onChange={(e) => onChangeGenerateInPlace?.(e.target.checked)}
+                  />
+                  <span className="rh-toggle-track">
+                    <span className="rh-toggle-knob" />
+                  </span>
+                </label>
+              </div>
+            </div>
           </div>
         )}
       </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -181,8 +181,10 @@ export interface BaseNodeData {
   aspectRatio?: string;       // 图片比例：'1:1' | '16:9' | ...
   batchCount?: number;        // 单次批量生成图片数量，默认 1
   batchGroupId?: string;      // 同一次批量生成的结果分组 ID
-  /** 视频节点：是否在当前节点生成并替换旧视频；false 时生成到右侧新建节点（可选 1-4 条）。默认 true。 */
+  /** 视频节点：是否在当前节点生成并替换旧视频；false 时生成到右侧新建节点（generateCount 条）。默认 true。 */
   generateInPlace?: boolean;
+  /** 视频节点：不在此节点生成时的新建数量（1-4），默认 1。 */
+  generateCount?: number;
   cameraSettings?: CameraGenerationSettings; // 生图/生视频摄影参数；字段缺省时由模型自动决定
   videoResolution?: number;   // 视频分辨率：832 | 1024 | 1280 | 1440
   videoFps?: number;          // 视频帧率：16 | 24 | 30

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -181,6 +181,8 @@ export interface BaseNodeData {
   aspectRatio?: string;       // 图片比例：'1:1' | '16:9' | ...
   batchCount?: number;        // 单次批量生成图片数量，默认 1
   batchGroupId?: string;      // 同一次批量生成的结果分组 ID
+  /** 视频节点：是否在当前节点生成并替换旧视频；false 时生成到右侧新建节点（可选 1-4 条）。默认 true。 */
+  generateInPlace?: boolean;
   cameraSettings?: CameraGenerationSettings; // 生图/生视频摄影参数；字段缺省时由模型自动决定
   videoResolution?: number;   // 视频分辨率：832 | 1024 | 1280 | 1440
   videoFps?: number;          // 视频帧率：16 | 24 | 30


### PR DESCRIPTION
## 视频节点多节点并行生成

### 功能

视频节点新增「在此节点生成」开关（默认开启）：

- **开启（默认）**：生成一条视频，直接替换当前节点旧视频（原有行为）
- **关闭**：参数区出现「生成数量」滑块（1-4 条），点击生成后：
  1. 立即在当前节点右侧创建对应数量的**空白占位节点**（显示生成中）
  2. **并行**向模型提交多个生成请求（大幅缩短总等待时间）
  3. 每条完成后视频自动填入对应节点，并建立连线（源节点 → 新节点）

### 改动文件

- \src/types/index.ts\：\BaseNodeData\ 新增 \generateInPlace\ / \generateCount\ 字段
- \src/components/nodes/AINodeDialog.tsx\：视频分支支持多节点并行生成（占位节点 + Promise.all 并行 + 结果回填）
- \src/components/nodes/shared/PromptPanel.tsx\：参数透传
- \src/components/nodes/shared/VideoParamSelector.tsx\：开关 + 数量滑块 UI（与时长滑块同款交互）

### 说明

- 未勾选时生成的节点继承源节点模型/参数，label 加序号（如 xxx-1）
- 生成失败对应节点标红显示错误，不影响其他并行任务
- 边界处理：项目/节点切换时中止；一次 addNodesWithEdges 提交全部节点与连线（单个历史快照）