### PR TITLE
feat(plugins): 收录逐帧拉片插件

### DIFF
--- a/public/plugin-marketplace.json
+++ b/public/plugin-marketplace.json
@@ -1,4 +1,9 @@
 {
   "schemaVersion": 1,
-  "plugins": []
+  "plugins": [
+    {
+      "repository": "https://github.com/luckcatlin2000/ai-canvas-video-frame-review-plugin",
+      "featured": false
+    }
+  ]
 }


### PR DESCRIPTION
为插件市场新增「逐帧拉片」普通条目（`featured: false`），使用户可从市场列表发现插件，再由现有 GitHub Release 流程读取和安装。

本次只有 `public/plugin-marketplace.json` 一处改动。

- 插件仓库：https://github.com/luckcatlin2000/ai-canvas-video-frame-review-plugin
- 正式版本：https://github.com/luckcatlin2000/ai-canvas-video-frame-review-plugin/releases/tag/v1.0.0
- 许可证：MIT
- Manifest ID：`com.ai-canvas.video-frame-review`
- 功能：视频采样、镜头校正、逐帧检查、视觉模型分析、人工复核及图片/分镜表与报告输出。

发布验证：插件构建和 25 项测试通过；Release 为非草稿、非预发布，版本号与 Manifest 一致，Manifest repository 与登记地址一致。使用现有市场解析器校验同一标签下的 Manifest、主脚本和 UI 脚本，解析为 ready，UI SHA-256 匹配。文件校验通过 GitHub Contents API 读取完成；验证环境访问 raw 域名有间歇性连接重置，因此未将其表述为实际安装验收通过。

运行需要宿主支持该插件声明的视频抽帧、逐帧检查、镜头检测、资源读取、模型调用和原子节点集输出能力。静态代表帧分析不等同于完整视频或音轨分析。
